### PR TITLE
feat: Dockerize DocuMind-AI application

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,48 @@
+# Git files
+.git/
+.gitignore
+
+# Python virtual environment
+venv/
+*.venv/
+
+# Python cache
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# Test files and directories
+tests/
+test/
+*.test.py
+*.spec.py
+requirements-dev.txt
+pytest.ini
+
+# IDE and editor directories
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS-specific files
+.DS_Store
+Thumbs.db
+
+# Documentation files (except README.md)
+Explanation.md
+# Add other markdown files if any, except README.md
+
+# Build artifacts
+dist/
+build/
+*.egg-info/
+
+# Secrets or local configuration (if any were planned)
+# .env
+
+# Docker files themselves if not needed inside image
+Dockerfile
+docker-compose.yml
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Use an official Python runtime as a parent image
+FROM python:3.9-slim
+
+# Set environment variables
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements file into the container at /app
+COPY requirements.txt .
+
+# Install any needed packages specified in requirements.txt
+# Using --no-cache-dir to reduce image size
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the application script and the document_store directory into the container at /app
+COPY rag_deep.py .
+COPY document_store/ ./document_store/
+
+# Make port 8501 available to the world outside this container
+EXPOSE 8501
+
+# Define the command to run the app
+# Running on 0.0.0.0 allows it to be accessible from outside the container
+# Ensure Streamlit uses the exposed port
+CMD ["streamlit", "run", "rag_deep.py", "--server.port", "8501", "--server.address", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -190,3 +190,60 @@ This will launch a local web server, typically at [http://localhost:8501](http:/
 
 - **Dependency Conflicts:**  
   If you encounter issues with package installations, ensure that your virtual environment is activated and that you are using the correct Python version.
+
+## Running with Docker
+
+This section provides instructions on how to run the DocuMind-AI application using Docker and Docker Compose.
+
+### Prerequisites
+
+- **Docker**: Install Docker Desktop (for Windows/Mac) or Docker Engine (for Linux). Download from [https://www.docker.com/products/docker-desktop/](https://www.docker.com/products/docker-desktop/).
+- **Docker Compose**: Included with Docker Desktop. For Linux, you might need to install it separately. See the [official Docker Compose installation guide](https://docs.docker.com/compose/install/).
+- **Ollama**: Must be installed and running on your system or accessible over the network. The DocuMind-AI application container needs to connect to your Ollama instance to use the language models. Ensure you have pulled the required model (e.g., `ollama pull deepseek-r1:1.5b`).
+
+### Setup & Running
+
+1.  **Clone the Repository**:
+    If you haven't already, clone the repository:
+    ```bash
+    git clone https://github.com/chintanboghara/DocuMind-AI.git
+    cd DocuMind-AI
+    ```
+
+2.  **Configure Ollama Access**:
+    *   The `docker-compose.yml` file included in this repository sets the `OLLAMA_BASE_URL` environment variable for the application container to `http://host.docker.internal:11434` by default. This address is typically used to allow a Docker container to access services running on the host machine when using Docker Desktop on Windows or Mac.
+    *   **If Ollama is running elsewhere** (e.g., on a different port, a different host machine, or in its own Docker container on a custom Docker network), you **must** update the `OLLAMA_BASE_URL` in the `docker-compose.yml` file.
+        ```yaml
+        services:
+          app:
+            # ... other configurations
+            environment:
+              - OLLAMA_BASE_URL=http://your-ollama-host-or-ip:your-ollama-port
+        ```
+    *   **Example for Linux users**: If Ollama is running on your host machine (the same machine running Docker), `host.docker.internal` may not resolve. You can often use your machine's IP address on the Docker bridge network (e.g., `172.17.0.1` by default on some systems, but this can vary). Alternatively, you can run Ollama in a Docker container and connect both containers to a shared Docker network.
+
+3.  **Build and Run the Application**:
+    Navigate to the root directory of the cloned repository (where `docker-compose.yml` is located) and run:
+    ```bash
+    docker-compose up --build -d
+    ```
+    - `--build`: Forces Docker Compose to build the image from the `Dockerfile` (useful for the first run or after changes).
+    - `-d`: Runs the containers in detached mode (in the background).
+
+4.  **Accessing the Application**:
+    *   Once the container is running (it might take a minute for the first build and startup), open your web browser and navigate to `http://localhost:8501`.
+
+5.  **Stopping the Application**:
+    To stop the application and remove the containers defined in `docker-compose.yml`, run:
+    ```bash
+    docker-compose down
+    ```
+
+### Persistent Storage
+
+- The `document_store/pdfs` directory (which stores uploaded documents) is mapped from your local machine into the container using a volume defined in `docker-compose.yml`:
+  ```yaml
+  volumes:
+    - ./document_store:/app/document_store/
+  ```
+- This means that any documents you upload will persist on your host machine even if the Docker container is stopped, removed, and rebuilt.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.8'
+
+services:
+  app:
+    build: .
+    ports:
+      - "8501:8501"
+    volumes:
+      - ./document_store:/app/document_store/
+    environment:
+      # Default to Ollama running on the Docker host.
+      # Users might need to change host.docker.internal depending on their OS
+      # or if Ollama is running in another container or remote.
+      - OLLAMA_BASE_URL=http://host.docker.internal:11434
+      # Set Streamlit specific environment variables if needed, e.g.,
+      # - STREAMLIT_SERVER_MAX_UPLOAD_SIZE=1028 
+      # (though this is usually configured in Streamlit's config file or command line)
+    # If your application needs to wait for Ollama or another service,
+    # you might add a healthcheck or depends_on condition here,
+    # but for now, we assume Ollama is independently managed and available.
+
+# Optional: Define a top-level volume if you prefer named volumes,
+# but bind mounts are often simpler for local development.
+# volumes:
+#   document_store_data:

--- a/rag_deep.py
+++ b/rag_deep.py
@@ -92,16 +92,19 @@ PDF_STORAGE_PATH = "document_store/pdfs/"
 # Ensure the PDF storage directory exists
 os.makedirs(PDF_STORAGE_PATH, exist_ok=True)
 
+# Fetch Ollama base URL from environment variable, with a default
+OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+
 # Cached functions to load models
 @st.cache_resource
 def get_embedding_model():
-    print("Loading Embedding Model...") # For debugging/verifying cache
-    return OllamaEmbeddings(model="deepseek-r1:1.5b")
+    print(f"Loading Embedding Model from: {OLLAMA_BASE_URL}") # For debugging/verifying cache
+    return OllamaEmbeddings(model="deepseek-r1:1.5b", base_url=OLLAMA_BASE_URL)
 
 @st.cache_resource
 def get_language_model():
-    print("Loading Language Model...") # For debugging/verifying cache
-    return OllamaLLM(model="deepseek-r1:1.5b")
+    print(f"Loading Language Model from: {OLLAMA_BASE_URL}") # For debugging/verifying cache
+    return OllamaLLM(model="deepseek-r1:1.5b", base_url=OLLAMA_BASE_URL)
 
 # Initialize models using cached functions
 EMBEDDING_MODEL = get_embedding_model()


### PR DESCRIPTION
This commit adds Docker support to the DocuMind-AI application, enabling easier setup, deployment, and consistent runtime environments.

Key changes:

1.  **`.dockerignore`**: Added to exclude unnecessary files from the Docker image, keeping it lean.
2.  **`Dockerfile`**: Created to define the application image. It uses a Python 3.9-slim base, installs dependencies, copies application code, and sets the command to run Streamlit.
3.  **`docker-compose.yml`**: Added to simplify management of the application container. It configures the build process, port mapping (8501:8501), volume mount for persistent PDF storage (`./document_store`), and sets the `OLLAMA_BASE_URL` environment variable for flexible Ollama server configuration.
4.  **Application Code (`rag_deep.py`)**: Modified to utilize the `OLLAMA_BASE_URL` environment variable when initializing Ollama embedding and language models, with a fallback to `http://localhost:11434`.
5.  **Documentation (`README.md`)**: Updated with a comprehensive "Running with Docker" section, including prerequisites, setup instructions, commands to build/run/stop the application via `docker-compose`, and guidance on configuring Ollama accessibility.