### PR TITLE
feat: Implement conversation history awareness

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 - **Document Processing:**  
   The assistant extracts text from the uploaded document, splits it into manageable chunks, and indexes the content using embeddings. This enables efficient retrieval and querying of the document's information.
 
-- **Intelligent Querying:**  
-  Ask questions about the document's content and receive concise, contextually relevant answers. The AI uses a language model to generate responses based on the document's context.
+- **Intelligent Querying with Conversation History:**  
+  Ask questions about the document's content and receive concise, contextually relevant answers. The AI uses a language model to generate responses based on the document's context and now considers recent conversation history (last 3 turns) to better understand follow-up questions.
 
 - **Document Summarization:**  
   Generate a concise summary of the entire document with a single click. The summary is displayed in the sidebar, providing a quick overview of the document's main points.


### PR DESCRIPTION
This commit introduces conversation history awareness to the DocuMind-AI application, enabling more natural follow-up questions.

Key changes:

1.  **Prompt Template:** Updated `PROMPT_TEMPLATE` to include a placeholder for `{conversation_history}` and instructed the LLM to use this context.
2.  **`generate_answer` Function:** Modified to accept an optional `conversation_history` string and pass it to the LLM prompt.
3.  **Chat Logic Integration:** The main chat loop now retrieves the last `MAX_HISTORY_TURNS` (currently 3) from your session's message history, formats it, and passes it to `generate_answer`.
4.  **Testing:** Added unit tests for `generate_answer` to verify that conversation history is correctly included in the prompt sent to the LLM.
5.  **Documentation:** Updated `README.md` and `Explanation.md` to reflect the new conversation history feature.