### PR TITLE
feat: Implement hybrid search with BM25 and RRF

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 - **Document Processing:**  
   The assistant extracts text from the uploaded document, splits it into manageable chunks, and indexes the content using embeddings. This enables efficient retrieval and querying of the document's information.
 
-- **Intelligent Querying with Conversation History:**  
-  Ask questions about the document's content and receive concise, contextually relevant answers. The AI uses a language model to generate responses based on the document's context and now considers recent conversation history (last 3 turns) to better understand follow-up questions.
+- **Intelligent Querying with Hybrid Search & Conversation History:**  
+  Ask questions about the document's content and receive concise, contextually relevant answers. The AI uses a language model to generate responses based on the document's context. It now employs a hybrid search strategy, combining semantic understanding (vector search) with BM25 keyword matching, and results are fused using Reciprocal Rank Fusion (RRF) for enhanced retrieval accuracy. Recent conversation history (last 3 turns) is also considered to better understand follow-up questions.
 
 - **Document Summarization:**  
   Generate a concise summary of the entire document with a single click. The summary is displayed in the sidebar, providing a quick overview of the document's main points.

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,6 @@ pdfplumber>=0.6.0
 
 # DOCX parsing
 python-docx>=1.1.0
+
+# BM25 ranking for retrieval
+rank-bm25>=0.2.2


### PR DESCRIPTION
This commit introduces a hybrid search mechanism to enhance document retrieval relevance. It combines semantic search (vector-based) with keyword-based search (BM25) and fuses the results using Reciprocal Rank Fusion (RRF).

Key changes:

1.  **BM25 Integration:**
    - Added `rank-bm25` library.
    - Implemented BM25 indexing of document chunks during processing. The BM25 index is stored in session state.
2.  **Hybrid Retrieval:**
    - Modified `find_related_documents` to perform both semantic similarity search and BM25 keyword search, returning results from both methods.
3.  **Reciprocal Rank Fusion (RRF):**
    - Implemented a `combine_results_rrf` function to merge and re-rank the document lists obtained from semantic and BM25 searches. This function uses the RRF algorithm to produce a single, more relevant list of documents.
4.  **Application Logic:**
    - Updated the main chat logic to use the RRF-combined document list for generating context for the LLM.
    - Ensured BM25 index and related data are managed correctly within the Streamlit session state (initialization, reset).
5.  **Testing:**
    - Added comprehensive unit tests for BM25 indexing, the updated `find_related_documents` retrieval logic, and the `combine_results_rrf` function, covering various scenarios.
6.  **Documentation:**
    - Updated `README.md` and `Explanation.md` to describe the new hybrid search functionality, BM25 indexing, and the RRF combination strategy.