### PR TITLE
Style: Apply automatic code formatting using Black

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -1,7 +1,9 @@
 import os
 
 # Global Application Constants
-MAX_HISTORY_TURNS = 3  # Number of recent user/assistant turn pairs to include in history
+MAX_HISTORY_TURNS = (
+    3  # Number of recent user/assistant turn pairs to include in history
+)
 K_SEMANTIC = 5  # Number of results for semantic search
 K_BM25 = 5  # Number of results for BM25 search
 K_RRF_PARAM = 60  # Constant for Reciprocal Rank Fusion (RRF)
@@ -45,9 +47,13 @@ Keywords:
 """
 
 # Model Names
-OLLAMA_EMBEDDING_MODEL_NAME = os.getenv("OLLAMA_EMBEDDING_MODEL_NAME", "deepseek-r1:1.5b")
+OLLAMA_EMBEDDING_MODEL_NAME = os.getenv(
+    "OLLAMA_EMBEDDING_MODEL_NAME", "deepseek-r1:1.5b"
+)
 OLLAMA_LLM_NAME = os.getenv("OLLAMA_LLM_NAME", "deepseek-r1:1.5b")
-RERANKER_MODEL_NAME = os.getenv("RERANKER_MODEL_NAME", "cross-encoder/ms-marco-MiniLM-L-6-v2")
+RERANKER_MODEL_NAME = os.getenv(
+    "RERANKER_MODEL_NAME", "cross-encoder/ms-marco-MiniLM-L-6-v2"
+)
 
 # Paths and URLs
 PDF_STORAGE_PATH = os.getenv("PDF_STORAGE_PATH", "document_store/pdfs/")

--- a/core/document_processing.py
+++ b/core/document_processing.py
@@ -10,6 +10,7 @@ from .logger_config import get_logger
 
 logger = get_logger(__name__)
 
+
 def save_uploaded_file(uploaded_file):
     """
     Save the uploaded file to disk and return the file path.
@@ -26,10 +27,13 @@ def save_uploaded_file(uploaded_file):
         st.error(user_message)
         return None
     except Exception as e:
-        user_message = f"An unexpected error occurred while saving '{uploaded_file.name}'."
+        user_message = (
+            f"An unexpected error occurred while saving '{uploaded_file.name}'."
+        )
         logger.exception(f"{user_message} Details: {e}")
         st.error(f"{user_message} Check logs for details.")
         return None
+
 
 def load_document(file_path):
     """
@@ -44,7 +48,9 @@ def load_document(file_path):
                 logger.debug(f"Loading PDF: {file_name}")
                 document_loader = PDFPlumberLoader(file_path)
                 docs = document_loader.load()
-                logger.info(f"Successfully loaded PDF: {file_name}, {len(docs)} pages/documents.")
+                logger.info(
+                    f"Successfully loaded PDF: {file_name}, {len(docs)} pages/documents."
+                )
                 return docs
             except pdfplumber.exceptions.PDFSyntaxError as pdf_err:
                 user_message = f"Failed to load PDF '{file_name}': The file may be corrupted or not a valid PDF."
@@ -62,18 +68,28 @@ def load_document(file_path):
                 doc = docx.Document(file_path)
                 full_text = "\n".join([para.text for para in doc.paragraphs])
                 if not full_text.strip():
-                    logger.warning(f"DOCX file '{file_name}' is empty or contains no text.")
-                    st.warning(f"DOCX file '{file_name}' appears to be empty or contains no text.")
+                    logger.warning(
+                        f"DOCX file '{file_name}' is empty or contains no text."
+                    )
+                    st.warning(
+                        f"DOCX file '{file_name}' appears to be empty or contains no text."
+                    )
                     return []
                 logger.info(f"Successfully loaded DOCX: {file_name}")
-                return [LangchainDocument(page_content=full_text, metadata={"source": file_name})]
+                return [
+                    LangchainDocument(
+                        page_content=full_text, metadata={"source": file_name}
+                    )
+                ]
             except docx.opc.exceptions.PackageNotFoundError as docx_err:
                 user_message = f"Failed to load DOCX '{file_name}': The file appears to be corrupted or not a valid DOCX file."
                 logger.error(f"{user_message} Details: {docx_err}")
                 st.error(user_message)
                 return []
             except Exception as e:
-                user_message = f"Failed to load DOCX '{file_name}': An unexpected error occurred."
+                user_message = (
+                    f"Failed to load DOCX '{file_name}': An unexpected error occurred."
+                )
                 logger.exception(f"{user_message} Details: {e}")
                 st.error(f"{user_message} Check logs for details.")
                 return []
@@ -87,7 +103,11 @@ def load_document(file_path):
                     st.warning(f"Text file '{file_name}' appears to be empty.")
                     return []
                 logger.info(f"Successfully loaded TXT: {file_name}")
-                return [LangchainDocument(page_content=full_text, metadata={"source": file_name})]
+                return [
+                    LangchainDocument(
+                        page_content=full_text, metadata={"source": file_name}
+                    )
+                ]
             except UnicodeDecodeError as unicode_err:
                 user_message = f"Failed to load TXT file '{file_name}': The file is not UTF-8 encoded. Please ensure it's a plain text file with UTF-8 encoding."
                 logger.error(f"{user_message} Details: {unicode_err}")
@@ -114,10 +134,13 @@ def load_document(file_path):
         st.error(user_message)
         return []
     except Exception as e:
-        user_message = f"An unexpected error occurred while attempting to load '{file_name}'."
+        user_message = (
+            f"An unexpected error occurred while attempting to load '{file_name}'."
+        )
         logger.exception(f"{user_message} Details: {e}")
         st.error(f"{user_message} Check logs for details.")
         return []
+
 
 def chunk_documents(raw_documents):
     """
@@ -125,7 +148,9 @@ def chunk_documents(raw_documents):
     """
     if not raw_documents:
         logger.warning("chunk_documents called with no raw documents.")
-        st.warning("No content found in the document to chunk.") # User feedback is fine
+        st.warning(
+            "No content found in the document to chunk."
+        )  # User feedback is fine
         return []
     logger.info(f"Starting to chunk {len(raw_documents)} raw document(s).")
     try:
@@ -137,7 +162,9 @@ def chunk_documents(raw_documents):
         processed_docs = text_processor.split_documents(raw_documents)
         if not processed_docs:
             logger.warning("Document chunking resulted in no processable text chunks.")
-            st.warning("Document chunking resulted in no processable text chunks. The document might be valid but contain no extractable text after initial processing, or the text is too short.") # User feedback fine
+            st.warning(
+                "Document chunking resulted in no processable text chunks. The document might be valid but contain no extractable text after initial processing, or the text is too short."
+            )  # User feedback fine
         else:
             logger.info(f"Chunking complete, {len(processed_docs)} chunks created.")
         return processed_docs
@@ -147,6 +174,7 @@ def chunk_documents(raw_documents):
         st.error(f"{user_message} Check logs for details.")
         return []
 
+
 def index_documents(document_chunks):
     """
     Add document chunks to the in-memory vector store.
@@ -154,7 +182,9 @@ def index_documents(document_chunks):
     """
     if not document_chunks:
         logger.warning("index_documents called with no chunks to index.")
-        st.warning("No document chunks available to index. This may happen if the document was empty or text extraction failed.") # User feedback fine
+        st.warning(
+            "No document chunks available to index. This may happen if the document was empty or text extraction failed."
+        )  # User feedback fine
         return
     logger.info(f"Indexing {len(document_chunks)} document chunks.")
     try:

--- a/core/generation.py
+++ b/core/generation.py
@@ -1,11 +1,18 @@
 import streamlit as st
 from langchain_core.prompts import ChatPromptTemplate
-from .config import PROMPT_TEMPLATE, SUMMARIZATION_PROMPT_TEMPLATE, KEYWORD_EXTRACTION_PROMPT_TEMPLATE
+from .config import (
+    PROMPT_TEMPLATE,
+    SUMMARIZATION_PROMPT_TEMPLATE,
+    KEYWORD_EXTRACTION_PROMPT_TEMPLATE,
+)
 from .logger_config import get_logger
 
 logger = get_logger(__name__)
 
-def generate_answer(language_model, user_query, context_documents, conversation_history=""):
+
+def generate_answer(
+    language_model, user_query, context_documents, conversation_history=""
+):
     """
     Generate an answer based on the user query, context documents, and conversation history.
     """
@@ -14,7 +21,11 @@ def generate_answer(language_model, user_query, context_documents, conversation_
         # User-facing warning is handled by returning the string, which rag_deep.py will show.
         return "Your question is empty. Please type a question to get an answer."
 
-    if not context_documents or not isinstance(context_documents, list) or len(context_documents) == 0:
+    if (
+        not context_documents
+        or not isinstance(context_documents, list)
+        or len(context_documents) == 0
+    ):
         logger.warning("generate_answer called with no context documents.")
         return "I couldn't find relevant information in the document to answer your query. Please try rephrasing your question or ensure the document contains the relevant topics."
 
@@ -22,29 +33,39 @@ def generate_answer(language_model, user_query, context_documents, conversation_
     try:
         context_text = "\n\n".join([doc.page_content for doc in context_documents])
         if not context_text.strip():
-            logger.warning("Context text for answer generation is empty after joining docs.")
+            logger.warning(
+                "Context text for answer generation is empty after joining docs."
+            )
             return "The relevant sections found in the document appear to be empty. Cannot generate an answer."
 
         logger.debug(f"Context for prompt: {context_text[:100]}...")
         conversation_prompt = ChatPromptTemplate.from_template(PROMPT_TEMPLATE)
         response_chain = conversation_prompt | language_model
 
-        response = response_chain.invoke({
-            "user_query": user_query,
-            "document_context": context_text,
-            "conversation_history": conversation_history
-        })
+        response = response_chain.invoke(
+            {
+                "user_query": user_query,
+                "document_context": context_text,
+                "conversation_history": conversation_history,
+            }
+        )
 
         if not response or not response.strip():
             logger.warning("AI model returned an empty response for answer generation.")
-            st.warning("The AI model returned an empty response. Please try rephrasing your question or try again later.") # User feedback
-            return "The AI model returned an empty response. Please try rephrasing your question or try again later." # Also return for main script
+            st.warning(
+                "The AI model returned an empty response. Please try rephrasing your question or try again later."
+            )  # User feedback
+            return "The AI model returned an empty response. Please try rephrasing your question or try again later."  # Also return for main script
         logger.info("Answer generated successfully.")
         return response
     except Exception as e:
-        user_message = "I'm sorry, but I encountered an error while trying to generate a response."
+        user_message = (
+            "I'm sorry, but I encountered an error while trying to generate a response."
+        )
         logger.exception(f"Error during answer generation: {e}")
-        st.error(f"An error occurred while generating the answer using the AI model. Details: {e}") # Keep for user if they see it via direct call
+        st.error(
+            f"An error occurred while generating the answer using the AI model. Details: {e}"
+        )  # Keep for user if they see it via direct call
         return f"{user_message} Please try again later or rephrase your question. (Details: {e})"
 
 
@@ -54,7 +75,9 @@ def generate_summary(language_model, full_document_text):
     """
     if not full_document_text or not full_document_text.strip():
         logger.warning("generate_summary called with empty document text.")
-        st.warning("Document content is empty or contains only whitespace. Cannot generate summary.")
+        st.warning(
+            "Document content is empty or contains only whitespace. Cannot generate summary."
+        )
         return None
     logger.info("Generating summary...")
     try:
@@ -63,14 +86,18 @@ def generate_summary(language_model, full_document_text):
         summary = summary_chain.invoke({"document_text": full_document_text})
         if not summary or not summary.strip():
             logger.warning("AI model returned an empty summary.")
-            st.warning("The AI model returned an empty summary. The document might be too short or lack clear content for summarization.")
+            st.warning(
+                "The AI model returned an empty summary. The document might be too short or lack clear content for summarization."
+            )
             return None
         logger.info("Summary generated successfully.")
         return summary
     except Exception as e:
         user_message = "Failed to generate summary due to an AI model error."
         logger.exception(f"Error during summary generation: {e}")
-        st.error(f"An error occurred while generating the document summary using the AI model. Details: {e}")
+        st.error(
+            f"An error occurred while generating the document summary using the AI model. Details: {e}"
+        )
         return f"{user_message} Please try again later. (Details: {e})"
 
 
@@ -80,21 +107,29 @@ def generate_keywords(language_model, full_document_text):
     """
     if not full_document_text or not full_document_text.strip():
         logger.warning("generate_keywords called with empty document text.")
-        st.warning("Document content is empty or contains only whitespace. Cannot extract keywords.")
+        st.warning(
+            "Document content is empty or contains only whitespace. Cannot extract keywords."
+        )
         return None
     logger.info("Generating keywords...")
     try:
-        keywords_prompt = ChatPromptTemplate.from_template(KEYWORD_EXTRACTION_PROMPT_TEMPLATE)
+        keywords_prompt = ChatPromptTemplate.from_template(
+            KEYWORD_EXTRACTION_PROMPT_TEMPLATE
+        )
         keywords_chain = keywords_prompt | language_model
         keywords = keywords_chain.invoke({"document_text": full_document_text})
         if not keywords or not keywords.strip():
             logger.warning("AI model returned no keywords.")
-            st.warning("The AI model returned no keywords. The document might be too short or lack distinct terms.")
+            st.warning(
+                "The AI model returned no keywords. The document might be too short or lack distinct terms."
+            )
             return None
         logger.info("Keywords generated successfully.")
         return keywords
     except Exception as e:
         user_message = "Failed to extract keywords due to an AI model error."
         logger.exception(f"Error during keyword generation: {e}")
-        st.error(f"An error occurred while extracting keywords using the AI model. Details: {e}")
+        st.error(
+            f"An error occurred while extracting keywords using the AI model. Details: {e}"
+        )
         return f"{user_message} Please try again later. (Details: {e})"

--- a/core/logger_config.py
+++ b/core/logger_config.py
@@ -2,6 +2,7 @@ import logging
 import os
 import sys
 
+
 def setup_logging():
     """
     Configures basic logging for the application.
@@ -13,27 +14,31 @@ def setup_logging():
 
     # Use a basic formatter for now, can be more detailed
     # Example: logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(name)s - %(message)s')
+    formatter = logging.Formatter(
+        "%(asctime)s - %(levelname)s - %(name)s - %(message)s"
+    )
 
     # Get the root logger
     # logger = logging.getLogger()
     # Using a specific logger for the app might be cleaner if other libs use root
-    logger = logging.getLogger("rag_app") # Specific logger for our app
+    logger = logging.getLogger("rag_app")  # Specific logger for our app
     logger.setLevel(log_level)
 
     # Remove existing handlers to avoid duplicate logs if this function is called multiple times
     # Though for st.cache_resource or module-level setup, this might not be an issue.
     # For a simple script, ensuring it's called once is key.
-    if not logger.handlers: # Add handler only if no handlers are configured.
+    if not logger.handlers:  # Add handler only if no handlers are configured.
         handler = logging.StreamHandler(sys.stdout)
         handler.setFormatter(formatter)
         logger.addHandler(handler)
 
     logger.info(f"Logging initialized with level {log_level_str}")
 
+
 # To make it easy to get this logger in other modules
 def get_logger(name):
     return logging.getLogger(f"rag_app.{name}")
+
 
 # Example of how a module would get its logger:
 # from .logger_config import get_logger

--- a/core/model_loader.py
+++ b/core/model_loader.py
@@ -2,20 +2,32 @@ import streamlit as st
 from langchain_ollama import OllamaEmbeddings
 from langchain_ollama.llms import OllamaLLM
 from sentence_transformers import CrossEncoder
-from .config import OLLAMA_BASE_URL, OLLAMA_EMBEDDING_MODEL_NAME, OLLAMA_LLM_NAME, RERANKER_MODEL_NAME
-from .logger_config import get_logger # Import the logger
+from .config import (
+    OLLAMA_BASE_URL,
+    OLLAMA_EMBEDDING_MODEL_NAME,
+    OLLAMA_LLM_NAME,
+    RERANKER_MODEL_NAME,
+)
+from .logger_config import get_logger  # Import the logger
 import requests
 
-logger = get_logger(__name__) # Initialize logger for this module
+logger = get_logger(__name__)  # Initialize logger for this module
+
 
 # Cached functions to load models
 @st.cache_resource
 def get_embedding_model():
     """Loads and caches the Ollama embedding model."""
-    logger.info(f"Attempting to load Embedding Model: {OLLAMA_EMBEDDING_MODEL_NAME} from: {OLLAMA_BASE_URL}")
+    logger.info(
+        f"Attempting to load Embedding Model: {OLLAMA_EMBEDDING_MODEL_NAME} from: {OLLAMA_BASE_URL}"
+    )
     try:
-        model = OllamaEmbeddings(model=OLLAMA_EMBEDDING_MODEL_NAME, base_url=OLLAMA_BASE_URL)
-        logger.info(f"Embedding Model {OLLAMA_EMBEDDING_MODEL_NAME} loaded successfully.")
+        model = OllamaEmbeddings(
+            model=OLLAMA_EMBEDDING_MODEL_NAME, base_url=OLLAMA_BASE_URL
+        )
+        logger.info(
+            f"Embedding Model {OLLAMA_EMBEDDING_MODEL_NAME} loaded successfully."
+        )
         # Attempt a simple operation to check connectivity, if available and cheap.
         # For OllamaEmbeddings, actual connection might be deferred.
         # If not, error will be caught on first use in the main script.
@@ -27,14 +39,19 @@ def get_embedding_model():
         return None
     except Exception as e:
         user_message = f"An unexpected error occurred while loading the Embedding Model ({OLLAMA_EMBEDDING_MODEL_NAME})."
-        logger.exception(f"{user_message} Details: {e}") # Use logger.exception to include stack trace
+        logger.exception(
+            f"{user_message} Details: {e}"
+        )  # Use logger.exception to include stack trace
         st.error(f"{user_message} Check logs for details.")
         return None
+
 
 @st.cache_resource
 def get_language_model():
     """Loads and caches the Ollama language model."""
-    logger.info(f"Attempting to load Language Model: {OLLAMA_LLM_NAME} from: {OLLAMA_BASE_URL}")
+    logger.info(
+        f"Attempting to load Language Model: {OLLAMA_LLM_NAME} from: {OLLAMA_BASE_URL}"
+    )
     try:
         model = OllamaLLM(model=OLLAMA_LLM_NAME, base_url=OLLAMA_BASE_URL)
         logger.info(f"Language Model {OLLAMA_LLM_NAME} loaded successfully.")
@@ -47,12 +64,15 @@ def get_language_model():
         return None
     except Exception as e:
         user_message = f"An unexpected error occurred while loading the Language Model ({OLLAMA_LLM_NAME})."
-        logger.exception(f"{user_message} Details: {e}") # Use logger.exception to include stack trace
+        logger.exception(
+            f"{user_message} Details: {e}"
+        )  # Use logger.exception to include stack trace
         st.error(f"{user_message} Check logs for details.")
         return None
 
+
 @st.cache_resource
-def get_reranker_model(): # model_name parameter removed, uses RERANKER_MODEL_NAME from config
+def get_reranker_model():  # model_name parameter removed, uses RERANKER_MODEL_NAME from config
     """
     Loads and caches the CrossEncoder model for re-ranking.
     Uses RERANKER_MODEL_NAME from config.
@@ -64,6 +84,8 @@ def get_reranker_model(): # model_name parameter removed, uses RERANKER_MODEL_NA
         return model
     except Exception as e:
         user_message = f"Error loading CrossEncoder model '{RERANKER_MODEL_NAME}'. Re-ranking will be disabled."
-        logger.exception(f"{user_message} Details: {e}") # Use logger.exception to include stack trace
+        logger.exception(
+            f"{user_message} Details: {e}"
+        )  # Use logger.exception to include stack trace
         st.error(f"{user_message} Check logs for details.")
         return None

--- a/core/search_pipeline.py
+++ b/core/search_pipeline.py
@@ -6,7 +6,10 @@ from .logger_config import get_logger
 
 logger = get_logger(__name__)
 
-def find_related_documents(query, document_vector_db, bm25_index, bm25_corpus_chunks, document_processed_flag):
+
+def find_related_documents(
+    query, document_vector_db, bm25_index, bm25_corpus_chunks, document_processed_flag
+):
     """
     Perform both semantic and BM25 search to find related document chunks.
     Returns a dictionary with 'semantic_results' and 'bm25_results'.
@@ -16,13 +19,23 @@ def find_related_documents(query, document_vector_db, bm25_index, bm25_corpus_ch
 
     if not query or not query.strip():
         logger.warning("find_related_documents called with empty query.")
-        st.warning("Search query is empty. Please enter a query to find related documents.")
-        return {"semantic_results": semantic_docs, "bm25_results": bm25_retrieved_chunks}
+        st.warning(
+            "Search query is empty. Please enter a query to find related documents."
+        )
+        return {
+            "semantic_results": semantic_docs,
+            "bm25_results": bm25_retrieved_chunks,
+        }
 
     if not document_processed_flag:
         logger.warning("find_related_documents called but no document processed.")
-        st.warning("No document has been processed yet. Please upload and process a document before searching.")
-        return {"semantic_results": semantic_docs, "bm25_results": bm25_retrieved_chunks}
+        st.warning(
+            "No document has been processed yet. Please upload and process a document before searching."
+        )
+        return {
+            "semantic_results": semantic_docs,
+            "bm25_results": bm25_retrieved_chunks,
+        }
 
     # 1. Semantic Search (Vector Search)
     logger.debug(f"Performing semantic search for query: '{query[:50]}...'")
@@ -48,11 +61,13 @@ def find_related_documents(query, document_vector_db, bm25_index, bm25_corpus_ch
             top_n_indices = sorted(
                 [i for i, score in enumerate(all_doc_scores) if score > 0],
                 key=lambda i: all_doc_scores[i],
-                reverse=True
+                reverse=True,
             )[:num_docs_to_consider]
 
             bm25_retrieved_chunks = [bm25_corpus_chunks[i] for i in top_n_indices]
-            logger.info(f"BM25 search found {len(bm25_retrieved_chunks)} results with positive scores.")
+            logger.info(
+                f"BM25 search found {len(bm25_retrieved_chunks)} results with positive scores."
+            )
         except Exception as e:
             user_message = "An error occurred during BM25 search."
             logger.exception(f"{user_message} Details: {e}")
@@ -63,6 +78,7 @@ def find_related_documents(query, document_vector_db, bm25_index, bm25_corpus_ch
         bm25_retrieved_chunks = []
 
     return {"semantic_results": semantic_docs, "bm25_results": bm25_retrieved_chunks}
+
 
 def combine_results_rrf(search_results_dict):
     """
@@ -87,11 +103,16 @@ def combine_results_rrf(search_results_dict):
         score = 1.0 / (K_RRF_PARAM + i + 1)
         doc_to_score[doc_id] = doc_to_score.get(doc_id, 0) + score
 
-    sorted_doc_ids = sorted(doc_to_score.keys(), key=lambda x: doc_to_score[x], reverse=True)
+    sorted_doc_ids = sorted(
+        doc_to_score.keys(), key=lambda x: doc_to_score[x], reverse=True
+    )
     final_combined_docs = [doc_objects[doc_id] for doc_id in sorted_doc_ids]
 
-    logger.info(f"RRF combined {len(semantic_results)} semantic and {len(bm25_results)} BM25 results into {len(final_combined_docs)} unique docs.")
+    logger.info(
+        f"RRF combined {len(semantic_results)} semantic and {len(bm25_results)} BM25 results into {len(final_combined_docs)} unique docs."
+    )
     return final_combined_docs
+
 
 def rerank_documents(query: str, documents: list, model: CrossEncoder, top_n: int):
     """
@@ -102,7 +123,9 @@ def rerank_documents(query: str, documents: list, model: CrossEncoder, top_n: in
         return []
     if model is None:
         logger.warning("Re-ranker model not available. Skipping re-ranking.")
-        st.warning("Re-ranker model not available. Returning documents without re-ranking.") # User feedback fine
+        st.warning(
+            "Re-ranker model not available. Returning documents without re-ranking."
+        )  # User feedback fine
         return documents[:top_n]
 
     logger.debug(f"Re-ranking {len(documents)} documents for query: '{query[:50]}...'")

--- a/core/session_manager.py
+++ b/core/session_manager.py
@@ -5,6 +5,7 @@ from .logger_config import get_logger
 
 logger = get_logger(__name__)
 
+
 def initialize_session_state():
     """
     Initializes the session state variables if they don't exist.
@@ -30,6 +31,7 @@ def initialize_session_state():
     if "bm25_corpus_chunks" not in st.session_state:
         st.session_state.bm25_corpus_chunks = []
 
+
 def reset_document_states(clear_chat=True):
     """
     Resets all document-related session state variables.
@@ -47,6 +49,7 @@ def reset_document_states(clear_chat=True):
     st.session_state.bm25_index = None
     st.session_state.bm25_corpus_chunks = []
     logger.info("Document states reset.")
+
 
 def reset_file_uploader():
     """Increments the key for the file uploader to reset it."""

--- a/rag_deep.py
+++ b/rag_deep.py
@@ -4,26 +4,43 @@ from rank_bm25 import BM25Okapi
 
 # Configure logging first
 from core.logger_config import setup_logging, get_logger
-setup_logging() # Initialize logging system
+
+setup_logging()  # Initialize logging system
 logger = get_logger(__name__)
 
 
 # Import from new core modules
 from core.config import (
-    MAX_HISTORY_TURNS, K_SEMANTIC, K_BM25, K_RRF_PARAM, TOP_K_FOR_RERANKER, FINAL_TOP_N_FOR_CONTEXT,
-    PDF_STORAGE_PATH
+    MAX_HISTORY_TURNS,
+    K_SEMANTIC,
+    K_BM25,
+    K_RRF_PARAM,
+    TOP_K_FOR_RERANKER,
+    FINAL_TOP_N_FOR_CONTEXT,
+    PDF_STORAGE_PATH,
 )
-from core.model_loader import get_embedding_model, get_language_model, get_reranker_model
+from core.model_loader import (
+    get_embedding_model,
+    get_language_model,
+    get_reranker_model,
+)
 from core.document_processing import (
-    save_uploaded_file, load_document, chunk_documents, index_documents
+    save_uploaded_file,
+    load_document,
+    chunk_documents,
+    index_documents,
 )
 from core.search_pipeline import (
-    find_related_documents, combine_results_rrf, rerank_documents
+    find_related_documents,
+    combine_results_rrf,
+    rerank_documents,
 )
-from core.generation import (
-    generate_answer, generate_summary, generate_keywords
+from core.generation import generate_answer, generate_summary, generate_keywords
+from core.session_manager import (
+    initialize_session_state,
+    reset_document_states,
+    reset_file_uploader,
 )
-from core.session_manager import initialize_session_state, reset_document_states, reset_file_uploader
 
 # ---------------------------------
 # App Styling with CSS
@@ -121,31 +138,49 @@ with st.sidebar:
     if st.session_state.document_processed:
         if st.button("Summarize Uploaded Content", key="summarize_content_button"):
             if st.session_state.raw_documents:
-                with st.spinner("Generating summary for all documents... This might take a few moments."):
-                    full_text = "\n\n".join([doc.page_content for doc in st.session_state.raw_documents])
+                with st.spinner(
+                    "Generating summary for all documents... This might take a few moments."
+                ):
+                    full_text = "\n\n".join(
+                        [doc.page_content for doc in st.session_state.raw_documents]
+                    )
                     if not full_text.strip():
-                        st.sidebar.warning("Cannot generate summary: Combined content of documents is effectively empty.")
-                        logger.warning("Summarization attempt on empty combined content.")
+                        st.sidebar.warning(
+                            "Cannot generate summary: Combined content of documents is effectively empty."
+                        )
+                        logger.warning(
+                            "Summarization attempt on empty combined content."
+                        )
                         st.session_state.document_summary = None
                     else:
                         logger.info("Generating combined content summary.")
                         summary_text = generate_summary(LANGUAGE_MODEL, full_text)
                         st.session_state.document_summary = summary_text
                         if "Failed to generate summary" in (summary_text or ""):
-                             logger.error(f"Summary generation failed: {summary_text}")
+                            logger.error(f"Summary generation failed: {summary_text}")
                         else:
-                             logger.info("Summary generated successfully.")
+                            logger.info("Summary generated successfully.")
             else:
-                st.sidebar.error("Cannot generate summary: Document content not loaded or available.")
+                st.sidebar.error(
+                    "Cannot generate summary: Document content not loaded or available."
+                )
                 logger.warning("Summarization attempt with no raw documents loaded.")
-        
-        if st.button("Extract Keywords from Content", key="extract_keywords_content_button"):
+
+        if st.button(
+            "Extract Keywords from Content", key="extract_keywords_content_button"
+        ):
             if st.session_state.raw_documents:
                 with st.spinner("Extracting keywords from all documents..."):
-                    full_text = "\n\n".join([doc.page_content for doc in st.session_state.raw_documents])
+                    full_text = "\n\n".join(
+                        [doc.page_content for doc in st.session_state.raw_documents]
+                    )
                     if not full_text.strip():
-                        st.sidebar.warning("Cannot extract keywords: Combined content of documents is effectively empty.")
-                        logger.warning("Keyword extraction attempt on empty combined content.")
+                        st.sidebar.warning(
+                            "Cannot extract keywords: Combined content of documents is effectively empty."
+                        )
+                        logger.warning(
+                            "Keyword extraction attempt on empty combined content."
+                        )
                         st.session_state.document_keywords = None
                     else:
                         logger.info("Extracting keywords from combined content.")
@@ -156,18 +191,30 @@ with st.sidebar:
                         else:
                             logger.info("Keywords extracted successfully.")
             else:
-                st.sidebar.error("Cannot extract keywords: Document content not loaded or available.")
-                logger.warning("Keyword extraction attempt with no raw documents loaded.")
-    
-    if st.session_state.document_summary and "Failed to generate summary" not in st.session_state.document_summary:
+                st.sidebar.error(
+                    "Cannot extract keywords: Document content not loaded or available."
+                )
+                logger.warning(
+                    "Keyword extraction attempt with no raw documents loaded."
+                )
+
+    if (
+        st.session_state.document_summary
+        and "Failed to generate summary" not in st.session_state.document_summary
+    ):
         st.sidebar.markdown("---")
         st.sidebar.subheader("📄 Combined Content Summary")
         st.sidebar.info(st.session_state.document_summary)
 
-    if st.session_state.document_keywords and "Failed to extract keywords" not in st.session_state.document_keywords:
+    if (
+        st.session_state.document_keywords
+        and "Failed to extract keywords" not in st.session_state.document_keywords
+    ):
         st.sidebar.markdown("---")
         st.sidebar.subheader("🔑 Extracted Keywords (Combined)")
-        st.sidebar.text_area("Keywords:", st.session_state.document_keywords, height=100, disabled=True)
+        st.sidebar.text_area(
+            "Keywords:", st.session_state.document_keywords, height=100, disabled=True
+        )
 
 st.title("📘 DocuMind-AI")
 st.markdown("### Your Intelligent Document Assistant")
@@ -178,14 +225,16 @@ uploaded_files = st.file_uploader(
     type=["pdf", "docx", "txt"],
     help="Select one or more PDF, DOCX, or TXT documents for analysis. Processing will begin upon upload. Re-uploading or changing files will reset the session.",
     accept_multiple_files=True,
-    key=f"file_uploader_{st.session_state.uploaded_file_key}"
+    key=f"file_uploader_{st.session_state.uploaded_file_key}",
 )
 
 if uploaded_files:
     current_uploaded_file_names = sorted([f.name for f in uploaded_files])
     logger.info(f"Files uploaded: {current_uploaded_file_names}")
 
-    if set(current_uploaded_file_names) != set(st.session_state.get('uploaded_filenames', [])):
+    if set(current_uploaded_file_names) != set(
+        st.session_state.get("uploaded_filenames", [])
+    ):
         logger.info("New set of files detected. Resetting document states.")
         reset_document_states(clear_chat=True)
 
@@ -205,7 +254,9 @@ if uploaded_files:
                         successfully_loaded_filenames.append(filename)
                         logger.info(f"Successfully loaded and parsed: {filename}")
                     else:
-                        st.error(f"Could not load document from '{filename}'. It might be empty, corrupted, or an unsupported type.")
+                        st.error(
+                            f"Could not load document from '{filename}'. It might be empty, corrupted, or an unsupported type."
+                        )
                         logger.error(f"Failed to load document from '{filename}'.")
                 else:
                     st.error(f"Failed to save '{filename}'. It will be skipped.")
@@ -215,43 +266,79 @@ if uploaded_files:
 
         if all_raw_docs_for_session:
             st.session_state.raw_documents = all_raw_docs_for_session
-            logger.info(f"Total {len(all_raw_docs_for_session)} raw documents collected from {len(successfully_loaded_filenames)} files.")
+            logger.info(
+                f"Total {len(all_raw_docs_for_session)} raw documents collected from {len(successfully_loaded_filenames)} files."
+            )
 
-            with st.spinner(f"Chunking and indexing {len(st.session_state.uploaded_filenames)} document(s)..."):
+            with st.spinner(
+                f"Chunking and indexing {len(st.session_state.uploaded_filenames)} document(s)..."
+            ):
                 logger.debug("Starting document chunking.")
                 processed_chunks = chunk_documents(st.session_state.raw_documents)
                 if processed_chunks:
                     logger.info(f"{len(processed_chunks)} chunks created.")
                     logger.debug("Starting document indexing.")
-                    index_documents(processed_chunks) # Modifies st.session_state
+                    index_documents(processed_chunks)  # Modifies st.session_state
 
                     if st.session_state.document_processed:
                         logger.info("Vector indexing successful.")
                         try:
                             logger.debug("Starting BM25 indexing.")
-                            corpus_texts = [chunk.page_content for chunk in processed_chunks]
-                            tokenized_corpus = [doc.lower().split(" ") for doc in corpus_texts]
+                            corpus_texts = [
+                                chunk.page_content for chunk in processed_chunks
+                            ]
+                            tokenized_corpus = [
+                                doc.lower().split(" ") for doc in corpus_texts
+                            ]
                             st.session_state.bm25_index = BM25Okapi(tokenized_corpus)
                             st.session_state.bm25_corpus_chunks = processed_chunks
-                            display_filenames = ", ".join(st.session_state.uploaded_filenames)
-                            logger.info(f"BM25 index created for documents: {display_filenames}")
-                            st.success(f"✅ Documents ({display_filenames}) processed and indexed successfully!")
+                            display_filenames = ", ".join(
+                                st.session_state.uploaded_filenames
+                            )
+                            logger.info(
+                                f"BM25 index created for documents: {display_filenames}"
+                            )
+                            st.success(
+                                f"✅ Documents ({display_filenames}) processed and indexed successfully!"
+                            )
                         except Exception as e:
-                            display_filenames = ", ".join(st.session_state.uploaded_filenames)
-                            logger.exception(f"Failed to create BM25 index for documents ({display_filenames}).")
-                            st.error(f"Failed to create BM25 index for documents ({display_filenames}). Vector indexing may still be active. Details: {e}")
+                            display_filenames = ", ".join(
+                                st.session_state.uploaded_filenames
+                            )
+                            logger.exception(
+                                f"Failed to create BM25 index for documents ({display_filenames})."
+                            )
+                            st.error(
+                                f"Failed to create BM25 index for documents ({display_filenames}). Vector indexing may still be active. Details: {e}"
+                            )
                     else:
-                        display_filenames = ", ".join(st.session_state.uploaded_filenames)
-                        logger.error(f"Vector indexing failed for documents ({display_filenames}). BM25 indexing skipped.")
-                        st.error(f"Documents ({display_filenames}) loaded but failed during vector indexing. BM25 indexing also skipped.")
+                        display_filenames = ", ".join(
+                            st.session_state.uploaded_filenames
+                        )
+                        logger.error(
+                            f"Vector indexing failed for documents ({display_filenames}). BM25 indexing skipped."
+                        )
+                        st.error(
+                            f"Documents ({display_filenames}) loaded but failed during vector indexing. BM25 indexing also skipped."
+                        )
                 else:
-                    logger.warning("No processable chunks generated from documents. Indexing skipped.")
-                    st.warning("No processable content found after loading all uploaded documents. Indexing skipped.")
+                    logger.warning(
+                        "No processable chunks generated from documents. Indexing skipped."
+                    )
+                    st.warning(
+                        "No processable content found after loading all uploaded documents. Indexing skipped."
+                    )
         elif not st.session_state.uploaded_filenames and uploaded_files:
-             logger.warning("Files were uploaded, but none could be successfully processed.")
-             st.warning("Although files were uploaded, none could be successfully processed. Please check file formats and content.")
+            logger.warning(
+                "Files were uploaded, but none could be successfully processed."
+            )
+            st.warning(
+                "Although files were uploaded, none could be successfully processed. Please check file formats and content."
+            )
 
-if st.session_state.get('uploaded_filenames') and st.session_state.get('document_processed'):
+if st.session_state.get("uploaded_filenames") and st.session_state.get(
+    "document_processed"
+):
     st.markdown("---")
     st.markdown(f"**Successfully processed document(s):**")
     for name in st.session_state.uploaded_filenames:
@@ -266,7 +353,9 @@ if st.session_state.document_processed:
     if len(st.session_state.uploaded_filenames) > 1:
         chat_placeholder = f"Ask a question about the {len(st.session_state.uploaded_filenames)} loaded documents..."
     elif len(st.session_state.uploaded_filenames) == 1:
-        chat_placeholder = f"Ask a question about '{st.session_state.uploaded_filenames[0]}'..."
+        chat_placeholder = (
+            f"Ask a question about '{st.session_state.uploaded_filenames[0]}'..."
+        )
     else:
         chat_placeholder = "Ask a question about the loaded document(s)..."
 
@@ -284,7 +373,10 @@ if st.session_state.document_processed:
                 num_messages_to_take = MAX_HISTORY_TURNS * 2
                 chat_log_for_prompt = st.session_state.messages[:-1]
                 chat_log_for_prompt = chat_log_for_prompt[-num_messages_to_take:]
-                history_lines = [f"{('User' if msg['role'] == 'user' else 'Assistant')}: {msg['content']}" for msg in chat_log_for_prompt]
+                history_lines = [
+                    f"{('User' if msg['role'] == 'user' else 'Assistant')}: {msg['content']}"
+                    for msg in chat_log_for_prompt
+                ]
                 formatted_history = "\n".join(history_lines)
                 logger.debug(f"Formatted history for prompt: {formatted_history}")
 
@@ -293,28 +385,51 @@ if st.session_state.document_processed:
                     st.session_state.DOCUMENT_VECTOR_DB,
                     st.session_state.bm25_index,
                     st.session_state.bm25_corpus_chunks,
-                    st.session_state.document_processed
+                    st.session_state.document_processed,
                 )
-                logger.info(f"Retrieved {len(retrieved_results_dict.get('semantic_results',[]))} semantic and {len(retrieved_results_dict.get('bm25_results',[]))} BM25 results.")
+                logger.info(
+                    f"Retrieved {len(retrieved_results_dict.get('semantic_results',[]))} semantic and {len(retrieved_results_dict.get('bm25_results',[]))} BM25 results."
+                )
 
                 hybrid_search_docs = combine_results_rrf(retrieved_results_dict)
-                logger.info(f"Combined RRF results: {len(hybrid_search_docs)} documents.")
+                logger.info(
+                    f"Combined RRF results: {len(hybrid_search_docs)} documents."
+                )
 
                 final_context_docs = []
                 if hybrid_search_docs:
                     docs_for_reranking = hybrid_search_docs[:TOP_K_FOR_RERANKER]
                     if RERANKER_MODEL:
-                        logger.debug(f"Re-ranking top {len(docs_for_reranking)} documents.")
-                        with st.spinner(f"Re-ranking top {len(docs_for_reranking)} documents..."):
-                            final_context_docs = rerank_documents(user_input, docs_for_reranking, RERANKER_MODEL, top_n=FINAL_TOP_N_FOR_CONTEXT)
-                        logger.info(f"Re-ranked results: {len(final_context_docs)} documents.")
+                        logger.debug(
+                            f"Re-ranking top {len(docs_for_reranking)} documents."
+                        )
+                        with st.spinner(
+                            f"Re-ranking top {len(docs_for_reranking)} documents..."
+                        ):
+                            final_context_docs = rerank_documents(
+                                user_input,
+                                docs_for_reranking,
+                                RERANKER_MODEL,
+                                top_n=FINAL_TOP_N_FOR_CONTEXT,
+                            )
+                        logger.info(
+                            f"Re-ranked results: {len(final_context_docs)} documents."
+                        )
                     else:
-                        logger.info("Re-ranker model not loaded. Using documents from hybrid search directly.")
-                        st.info("Re-ranker model not loaded. Using documents from hybrid search directly (top results).")
-                        final_context_docs = docs_for_reranking[:FINAL_TOP_N_FOR_CONTEXT]
+                        logger.info(
+                            "Re-ranker model not loaded. Using documents from hybrid search directly."
+                        )
+                        st.info(
+                            "Re-ranker model not loaded. Using documents from hybrid search directly (top results)."
+                        )
+                        final_context_docs = docs_for_reranking[
+                            :FINAL_TOP_N_FOR_CONTEXT
+                        ]
 
                     if not final_context_docs:
-                        logger.warning("No relevant sections found after re-ranking (or hybrid search if reranker disabled).")
+                        logger.warning(
+                            "No relevant sections found after re-ranking (or hybrid search if reranker disabled)."
+                        )
                         ai_response = "After re-ranking, no relevant sections were found in the loaded documents to answer your query."
                     else:
                         logger.debug("Generating answer with final context documents.")
@@ -322,15 +437,21 @@ if st.session_state.document_processed:
                             LANGUAGE_MODEL,
                             user_query=user_input,
                             context_documents=final_context_docs,
-                            conversation_history=formatted_history
+                            conversation_history=formatted_history,
                         )
                 else:
                     logger.warning("No relevant sections found from hybrid search.")
                     ai_response = "I could not find relevant sections in the loaded documents to answer your query. Please ensure the documents contain information related to your query or try rephrasing."
-            
-            logger.info(f"AI Response: {ai_response[:100]}...") # Log snippet of AI response
-            st.session_state.messages.append({"role": "assistant", "content": ai_response, "avatar": "🤖"})
+
+            logger.info(
+                f"AI Response: {ai_response[:100]}..."
+            )  # Log snippet of AI response
+            st.session_state.messages.append(
+                {"role": "assistant", "content": ai_response, "avatar": "🤖"}
+            )
             with st.chat_message("assistant", avatar="🤖"):
                 st.write(ai_response)
 else:
-    st.info("Please upload one or more PDF, DOCX, or TXT documents to begin your session and ask questions.")
+    st.info(
+        "Please upload one or more PDF, DOCX, or TXT documents to begin your session and ask questions."
+    )

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -8,9 +8,10 @@ import importlib
 # For robust imports, especially if using a test runner that might change sys.path,
 # consider adding the project root to sys.path or using relative imports if tests are part of the package.
 # For now, let's assume `core` is in PYTHONPATH or the test runner handles it.
-from core import config # Initial import
+from core import config  # Initial import
 
 # --- Tests for Environment Variable Configurations ---
+
 
 @pytest.fixture(autouse=True)
 def manage_os_environ():
@@ -20,20 +21,25 @@ def manage_os_environ():
     os.environ.clear()
     os.environ.update(original_environ)
 
+
 def test_ollama_base_url_default():
     # Ensure env var is not set for this test by clearing it specifically for this context
-    with patch.dict(os.environ, {}, clear=True): # Clears all, then use fixture to restore
+    with patch.dict(
+        os.environ, {}, clear=True
+    ):  # Clears all, then use fixture to restore
         # Need to remove the specific key if it was set by the system/shell
         if "OLLAMA_BASE_URL" in os.environ:
             del os.environ["OLLAMA_BASE_URL"]
         importlib.reload(config)
         assert config.OLLAMA_BASE_URL == "http://localhost:11434"
 
+
 def test_ollama_base_url_env_override():
     test_url = "http://customhost:12345"
     with patch.dict(os.environ, {"OLLAMA_BASE_URL": test_url}):
         importlib.reload(config)
         assert config.OLLAMA_BASE_URL == test_url
+
 
 def test_ollama_embedding_model_name_default():
     with patch.dict(os.environ, {}, clear=True):
@@ -42,11 +48,13 @@ def test_ollama_embedding_model_name_default():
         importlib.reload(config)
         assert config.OLLAMA_EMBEDDING_MODEL_NAME == "deepseek-r1:1.5b"
 
+
 def test_ollama_embedding_model_name_env_override():
     test_model = "custom_embed_model"
     with patch.dict(os.environ, {"OLLAMA_EMBEDDING_MODEL_NAME": test_model}):
         importlib.reload(config)
         assert config.OLLAMA_EMBEDDING_MODEL_NAME == test_model
+
 
 def test_ollama_llm_name_default():
     with patch.dict(os.environ, {}, clear=True):
@@ -55,11 +63,13 @@ def test_ollama_llm_name_default():
         importlib.reload(config)
         assert config.OLLAMA_LLM_NAME == "deepseek-r1:1.5b"
 
+
 def test_ollama_llm_name_env_override():
     test_model = "custom_llm_name"
     with patch.dict(os.environ, {"OLLAMA_LLM_NAME": test_model}):
         importlib.reload(config)
         assert config.OLLAMA_LLM_NAME == test_model
+
 
 def test_reranker_model_name_default():
     with patch.dict(os.environ, {}, clear=True):
@@ -68,11 +78,13 @@ def test_reranker_model_name_default():
         importlib.reload(config)
         assert config.RERANKER_MODEL_NAME == "cross-encoder/ms-marco-MiniLM-L-6-v2"
 
+
 def test_reranker_model_name_env_override():
     test_model = "custom_reranker"
     with patch.dict(os.environ, {"RERANKER_MODEL_NAME": test_model}):
         importlib.reload(config)
         assert config.RERANKER_MODEL_NAME == test_model
+
 
 def test_pdf_storage_path_default():
     with patch.dict(os.environ, {}, clear=True):
@@ -81,52 +93,66 @@ def test_pdf_storage_path_default():
         importlib.reload(config)
         assert config.PDF_STORAGE_PATH == "document_store/pdfs/"
 
+
 def test_pdf_storage_path_env_override():
     test_path = "/mnt/custom_storage/"
     with patch.dict(os.environ, {"PDF_STORAGE_PATH": test_path}):
         importlib.reload(config)
         assert config.PDF_STORAGE_PATH == test_path
 
+
 # --- Tests for Hardcoded Constants (Lower Priority) ---
 
+
 def test_max_history_turns_value():
-    importlib.reload(config) # Ensure we have the module's current state if other tests modified it via env
+    importlib.reload(
+        config
+    )  # Ensure we have the module's current state if other tests modified it via env
     assert config.MAX_HISTORY_TURNS == 3
+
 
 def test_k_semantic_value():
     importlib.reload(config)
     assert config.K_SEMANTIC == 5
 
+
 def test_k_bm25_value():
     importlib.reload(config)
     assert config.K_BM25 == 5
+
 
 def test_k_rrf_param_value():
     importlib.reload(config)
     assert config.K_RRF_PARAM == 60
 
+
 def test_top_k_for_reranker_value():
     importlib.reload(config)
     assert config.TOP_K_FOR_RERANKER == 10
+
 
 def test_final_top_n_for_context_value():
     importlib.reload(config)
     assert config.FINAL_TOP_N_FOR_CONTEXT == 3
 
+
 def test_prompt_template_exists_and_type():
     importlib.reload(config)
     assert isinstance(config.PROMPT_TEMPLATE, str)
-    assert "{user_query}" in config.PROMPT_TEMPLATE # Basic check for content
+    assert "{user_query}" in config.PROMPT_TEMPLATE  # Basic check for content
+
 
 def test_summarization_prompt_template_exists_and_type():
     importlib.reload(config)
     assert isinstance(config.SUMMARIZATION_PROMPT_TEMPLATE, str)
     assert "{document_text}" in config.SUMMARIZATION_PROMPT_TEMPLATE
 
+
 def test_keyword_extraction_prompt_template_exists_and_type():
     importlib.reload(config)
     assert isinstance(config.KEYWORD_EXTRACTION_PROMPT_TEMPLATE, str)
     assert "{document_text}" in config.KEYWORD_EXTRACTION_PROMPT_TEMPLATE
+
 
 # Note: LOG_LEVEL is tested in test_logger_config.py as it's directly used there.
 # The pattern in config.py (os.getenv) is tested by the variables above.

--- a/tests/core/test_document_processing.py
+++ b/tests/core/test_document_processing.py
@@ -4,8 +4,10 @@ from unittest.mock import patch, MagicMock, mock_open
 
 # Import LangchainDocument for creating test data
 from langchain_core.documents import Document as LangchainDocument
+
 # Specific error for DOCX
 from docx.opc.exceptions import PackageNotFoundError
+
 # Specific error for PDF
 import pdfplumber
 
@@ -14,29 +16,30 @@ from core.document_processing import (
     save_uploaded_file,
     load_document,
     chunk_documents,
-    index_documents
+    index_documents,
 )
 
 # Import config to use/mock its values, and logger for mocking
-from core import config # For PDF_STORAGE_PATH
+from core import config  # For PDF_STORAGE_PATH
+
 # core.logger_config is not directly imported here, but we'll patch the logger instance
 # used within document_processing.py, which is 'core.document_processing.logger'
 
 # Paths for mocking
-MOCK_OPEN_PATH = 'builtins.open'
-OS_PATH_JOIN_PATH = 'os.path.join'
-OS_PATH_BASENAME_PATH = 'os.path.basename' # Used by load_document
-PDF_PLUMBER_LOADER_PATH = 'core.document_processing.PDFPlumberLoader'
-DOCX_MODULE_PATH = 'core.document_processing.docx' # To mock docx.Document
-RECURSIVE_SPLITTER_PATH = 'core.document_processing.RecursiveCharacterTextSplitter'
-STREAMLIT_ERROR_PATH = 'core.document_processing.st.error'
-STREAMLIT_WARNING_PATH = 'core.document_processing.st.warning'
-DOCUMENT_PROCESSING_LOGGER_PATH = 'core.document_processing.logger'
+MOCK_OPEN_PATH = "builtins.open"
+OS_PATH_JOIN_PATH = "os.path.join"
+OS_PATH_BASENAME_PATH = "os.path.basename"  # Used by load_document
+PDF_PLUMBER_LOADER_PATH = "core.document_processing.PDFPlumberLoader"
+DOCX_MODULE_PATH = "core.document_processing.docx"  # To mock docx.Document
+RECURSIVE_SPLITTER_PATH = "core.document_processing.RecursiveCharacterTextSplitter"
+STREAMLIT_ERROR_PATH = "core.document_processing.st.error"
+STREAMLIT_WARNING_PATH = "core.document_processing.st.warning"
+DOCUMENT_PROCESSING_LOGGER_PATH = "core.document_processing.logger"
 
 
 # Define the path to test data files - these files won't exist in this environment
 # but tests for load_document will mock their loading.
-TEST_DATA_DIR = "test_data_dummy" # Dummy dir, actual file content will be mocked
+TEST_DATA_DIR = "test_data_dummy"  # Dummy dir, actual file content will be mocked
 SAMPLE_TXT_PATH = os.path.join(TEST_DATA_DIR, "sample.txt")
 SAMPLE_DOCX_PATH = os.path.join(TEST_DATA_DIR, "sample.docx")
 EMPTY_TXT_PATH = os.path.join(TEST_DATA_DIR, "empty.txt")
@@ -54,7 +57,9 @@ def mock_logger_fixture():
     with patch(DOCUMENT_PROCESSING_LOGGER_PATH) as mock_log:
         yield mock_log
 
+
 # --- Tests for save_uploaded_file (from previous step, confirmed good) ---
+
 
 @patch(OS_PATH_JOIN_PATH, return_value="/fake/path/to/file.pdf")
 @patch(MOCK_OPEN_PATH)
@@ -63,20 +68,24 @@ def test_save_uploaded_file_success(mock_open_file, mock_os_join, mock_logger_fi
     mock_uploaded_file.name = "file.pdf"
     mock_uploaded_file.getbuffer.return_value = b"file_content"
 
-    with patch.object(config, 'PDF_STORAGE_PATH', '/fake/storage'):
+    with patch.object(config, "PDF_STORAGE_PATH", "/fake/storage"):
         result_path = save_uploaded_file(mock_uploaded_file)
 
-    mock_os_join.assert_called_once_with('/fake/storage', "file.pdf")
+    mock_os_join.assert_called_once_with("/fake/storage", "file.pdf")
     mock_open_file.assert_called_once_with("/fake/path/to/file.pdf", "wb")
     mock_open_file().write.assert_called_once_with(b"file_content")
     assert result_path == "/fake/path/to/file.pdf"
-    mock_logger_fixture.info.assert_called_once_with("File 'file.pdf' saved to '/fake/path/to/file.pdf'.")
+    mock_logger_fixture.info.assert_called_once_with(
+        "File 'file.pdf' saved to '/fake/path/to/file.pdf'."
+    )
 
 
 @patch(OS_PATH_JOIN_PATH, return_value="/fake/path/to/file.pdf")
 @patch(MOCK_OPEN_PATH, side_effect=IOError("Disk full"))
 @patch(STREAMLIT_ERROR_PATH)
-def test_save_uploaded_file_io_error(mock_st_error, mock_open_file, mock_os_join, mock_logger_fixture):
+def test_save_uploaded_file_io_error(
+    mock_st_error, mock_open_file, mock_os_join, mock_logger_fixture
+):
     mock_uploaded_file = MagicMock()
     mock_uploaded_file.name = "file.pdf"
     mock_uploaded_file.getbuffer.return_value = b"file_content"
@@ -90,8 +99,13 @@ def test_save_uploaded_file_io_error(mock_st_error, mock_open_file, mock_os_join
 
 # --- Tests for load_document (Adapted from test_rag_deep.py) ---
 
+
 @patch(OS_PATH_BASENAME_PATH, return_value="sample.txt")
-@patch(MOCK_OPEN_PATH, new_callable=mock_open, read_data="This is a test content from a TXT file.\nIt has multiple lines.")
+@patch(
+    MOCK_OPEN_PATH,
+    new_callable=mock_open,
+    read_data="This is a test content from a TXT file.\nIt has multiple lines.",
+)
 def test_load_document_txt_success(mock_file, mock_basename, mock_logger_fixture):
     documents = load_document(SAMPLE_TXT_PATH)
     assert isinstance(documents, list)
@@ -101,9 +115,12 @@ def test_load_document_txt_success(mock_file, mock_basename, mock_logger_fixture
     assert documents[0].metadata["source"] == "sample.txt"
     mock_logger_fixture.info.assert_called_with("Successfully loaded TXT: sample.txt")
 
+
 @patch(OS_PATH_BASENAME_PATH, return_value="sample.docx")
-@patch(DOCX_MODULE_PATH) # Mock 'core.document_processing.docx'
-def test_load_document_docx_success(mock_docx_module, mock_basename, mock_logger_fixture):
+@patch(DOCX_MODULE_PATH)  # Mock 'core.document_processing.docx'
+def test_load_document_docx_success(
+    mock_docx_module, mock_basename, mock_logger_fixture
+):
     mock_doc_obj = MagicMock()
     mock_para1 = MagicMock()
     mock_para1.text = "This is test content from a DOCX file."
@@ -118,96 +135,149 @@ def test_load_document_docx_success(mock_docx_module, mock_basename, mock_logger
     assert documents[0].metadata["source"] == "sample.docx"
     mock_logger_fixture.info.assert_called_with("Successfully loaded DOCX: sample.docx")
 
+
 @patch(OS_PATH_BASENAME_PATH, return_value="empty.txt")
 @patch(MOCK_OPEN_PATH, new_callable=mock_open, read_data="")
 @patch(STREAMLIT_WARNING_PATH)
-def test_load_document_empty_txt(mock_st_warning, mock_file, mock_basename, mock_logger_fixture):
+def test_load_document_empty_txt(
+    mock_st_warning, mock_file, mock_basename, mock_logger_fixture
+):
     documents = load_document(EMPTY_TXT_PATH)
     assert documents == []
-    mock_st_warning.assert_called_once_with(f"Text file '{os.path.basename(EMPTY_TXT_PATH)}' appears to be empty.")
-    mock_logger_fixture.warning.assert_called_with(f"Text file '{os.path.basename(EMPTY_TXT_PATH)}' is empty.")
+    mock_st_warning.assert_called_once_with(
+        f"Text file '{os.path.basename(EMPTY_TXT_PATH)}' appears to be empty."
+    )
+    mock_logger_fixture.warning.assert_called_with(
+        f"Text file '{os.path.basename(EMPTY_TXT_PATH)}' is empty."
+    )
+
 
 @patch(OS_PATH_BASENAME_PATH, return_value="empty.docx")
 @patch(DOCX_MODULE_PATH)
 @patch(STREAMLIT_WARNING_PATH)
-def test_load_document_empty_docx(mock_st_warning, mock_docx_module, mock_basename, mock_logger_fixture):
+def test_load_document_empty_docx(
+    mock_st_warning, mock_docx_module, mock_basename, mock_logger_fixture
+):
     mock_doc_obj = MagicMock()
-    mock_doc_obj.paragraphs = [] # No paragraphs or paragraphs with no text
+    mock_doc_obj.paragraphs = []  # No paragraphs or paragraphs with no text
     mock_docx_module.Document.return_value = mock_doc_obj
     documents = load_document(EMPTY_DOCX_PATH)
     assert documents == []
-    mock_st_warning.assert_called_once_with(f"DOCX file '{os.path.basename(EMPTY_DOCX_PATH)}' appears to be empty or contains no text.")
-    mock_logger_fixture.warning.assert_called_with(f"DOCX file '{os.path.basename(EMPTY_DOCX_PATH)}' is empty or contains no text.")
+    mock_st_warning.assert_called_once_with(
+        f"DOCX file '{os.path.basename(EMPTY_DOCX_PATH)}' appears to be empty or contains no text."
+    )
+    mock_logger_fixture.warning.assert_called_with(
+        f"DOCX file '{os.path.basename(EMPTY_DOCX_PATH)}' is empty or contains no text."
+    )
 
 
 @patch(OS_PATH_BASENAME_PATH, return_value="sample.png")
 @patch(STREAMLIT_ERROR_PATH)
-def test_load_document_unsupported_type(mock_st_error, mock_basename, mock_logger_fixture):
-    documents = load_document(UNSUPPORTED_FILE_PATH) # .png is unsupported
+def test_load_document_unsupported_type(
+    mock_st_error, mock_basename, mock_logger_fixture
+):
+    documents = load_document(UNSUPPORTED_FILE_PATH)  # .png is unsupported
     assert documents == []
-    mock_st_error.assert_called_once_with("Unsupported file type: '.png' for file 'sample.png'. Please upload a PDF, DOCX, or TXT file.")
-    mock_logger_fixture.warning.assert_called_with("Unsupported file type: '.png' for file 'sample.png'. Please upload a PDF, DOCX, or TXT file.")
+    mock_st_error.assert_called_once_with(
+        "Unsupported file type: '.png' for file 'sample.png'. Please upload a PDF, DOCX, or TXT file."
+    )
+    mock_logger_fixture.warning.assert_called_with(
+        "Unsupported file type: '.png' for file 'sample.png'. Please upload a PDF, DOCX, or TXT file."
+    )
 
 
 @patch(OS_PATH_BASENAME_PATH, return_value="non_existent.txt")
 @patch(MOCK_OPEN_PATH, side_effect=FileNotFoundError("File not found"))
-@patch(STREAMLIT_ERROR_PATH) # load_document calls st.error in its generic exception handler
-def test_load_document_non_existent_file(mock_st_error, mock_file_open, mock_basename, mock_logger_fixture):
-    documents = load_document(NON_EXISTENT_TXT_PATH) # Path for a .txt file
+@patch(
+    STREAMLIT_ERROR_PATH
+)  # load_document calls st.error in its generic exception handler
+def test_load_document_non_existent_file(
+    mock_st_error, mock_file_open, mock_basename, mock_logger_fixture
+):
+    documents = load_document(NON_EXISTENT_TXT_PATH)  # Path for a .txt file
     assert documents == []
-    mock_st_error.assert_called_once() # Check that st.error was called
+    mock_st_error.assert_called_once()  # Check that st.error was called
     # More specific check for the logger message
     mock_logger_fixture.exception.assert_called_once()
 
 
 @patch(OS_PATH_BASENAME_PATH, return_value="corrupted.docx")
-@patch(DOCX_MODULE_PATH) # Mock 'core.document_processing.docx'
+@patch(DOCX_MODULE_PATH)  # Mock 'core.document_processing.docx'
 @patch(STREAMLIT_ERROR_PATH)
-def test_load_document_corrupted_docx(mock_st_error, mock_docx_module, mock_basename, mock_logger_fixture):
-    mock_docx_module.Document.side_effect = PackageNotFoundError("Mocked error: Corrupted DOCX")
+def test_load_document_corrupted_docx(
+    mock_st_error, mock_docx_module, mock_basename, mock_logger_fixture
+):
+    mock_docx_module.Document.side_effect = PackageNotFoundError(
+        "Mocked error: Corrupted DOCX"
+    )
     documents = load_document(CORRUPTED_DOCX_PATH)
     assert documents == []
-    mock_st_error.assert_called_once_with(f"Failed to load DOCX '{os.path.basename(CORRUPTED_DOCX_PATH)}': The file appears to be corrupted or not a valid DOCX file.")
+    mock_st_error.assert_called_once_with(
+        f"Failed to load DOCX '{os.path.basename(CORRUPTED_DOCX_PATH)}': The file appears to be corrupted or not a valid DOCX file."
+    )
     mock_logger_fixture.error.assert_called_once()
+
 
 @patch(OS_PATH_BASENAME_PATH, return_value="bad_encoding.txt")
 @patch(MOCK_OPEN_PATH, new_callable=mock_open)
 @patch(STREAMLIT_ERROR_PATH)
-def test_load_document_txt_unicode_decode_error(mock_st_error, mock_file_open, mock_basename, mock_logger_fixture):
+def test_load_document_txt_unicode_decode_error(
+    mock_st_error, mock_file_open, mock_basename, mock_logger_fixture
+):
     # Configure the mock_open instance to raise UnicodeDecodeError on read
     mock_file_instance = mock_file_open.return_value
-    mock_file_instance.read.side_effect = UnicodeDecodeError("utf-8", b"\x80", 0, 1, "invalid start byte")
+    mock_file_instance.read.side_effect = UnicodeDecodeError(
+        "utf-8", b"\x80", 0, 1, "invalid start byte"
+    )
 
     documents = load_document(BAD_ENCODING_TXT_PATH)
     assert documents == []
-    mock_st_error.assert_called_once_with(f"Failed to load TXT file '{os.path.basename(BAD_ENCODING_TXT_PATH)}': The file is not UTF-8 encoded. Please ensure it's a plain text file with UTF-8 encoding.")
+    mock_st_error.assert_called_once_with(
+        f"Failed to load TXT file '{os.path.basename(BAD_ENCODING_TXT_PATH)}': The file is not UTF-8 encoded. Please ensure it's a plain text file with UTF-8 encoding."
+    )
     mock_logger_fixture.error.assert_called_once()
+
 
 @patch(OS_PATH_BASENAME_PATH, return_value="corrupted.pdf")
 @patch(PDF_PLUMBER_LOADER_PATH)
 @patch(STREAMLIT_ERROR_PATH)
-def test_load_document_pdf_syntax_error(mock_st_error, mock_pdf_loader, mock_basename, mock_logger_fixture):
+def test_load_document_pdf_syntax_error(
+    mock_st_error, mock_pdf_loader, mock_basename, mock_logger_fixture
+):
     mock_loader_instance = mock_pdf_loader.return_value
-    mock_loader_instance.load.side_effect = pdfplumber.exceptions.PDFSyntaxError("Mocked PDF Syntax Error")
+    mock_loader_instance.load.side_effect = pdfplumber.exceptions.PDFSyntaxError(
+        "Mocked PDF Syntax Error"
+    )
     documents = load_document(CORRUPTED_PDF_PATH)
     assert documents == []
-    mock_st_error.assert_called_once_with(f"Failed to load PDF '{os.path.basename(CORRUPTED_PDF_PATH)}': The file may be corrupted or not a valid PDF.")
+    mock_st_error.assert_called_once_with(
+        f"Failed to load PDF '{os.path.basename(CORRUPTED_PDF_PATH)}': The file may be corrupted or not a valid PDF."
+    )
     mock_logger_fixture.error.assert_called_once()
 
 
 # --- Tests for chunk_documents (from previous step, confirmed good) ---
 
+
 @patch(RECURSIVE_SPLITTER_PATH)
 def test_chunk_documents_success(mock_splitter_class, mock_logger_fixture):
     mock_splitter_instance = MagicMock()
-    mock_chunk = LangchainDocument(page_content="chunked content", metadata={"source": "test.pdf"})
+    mock_chunk = LangchainDocument(
+        page_content="chunked content", metadata={"source": "test.pdf"}
+    )
     mock_splitter_instance.split_documents.return_value = [mock_chunk]
     mock_splitter_class.return_value = mock_splitter_instance
 
-    raw_docs = [LangchainDocument(page_content="This is a long document.", metadata={"source": "test.pdf"})]
+    raw_docs = [
+        LangchainDocument(
+            page_content="This is a long document.", metadata={"source": "test.pdf"}
+        )
+    ]
     chunks = chunk_documents(raw_docs)
 
-    mock_splitter_class.assert_called_once_with(chunk_size=1000, chunk_overlap=200, add_start_index=True)
+    mock_splitter_class.assert_called_once_with(
+        chunk_size=1000, chunk_overlap=200, add_start_index=True
+    )
     mock_splitter_instance.split_documents.assert_called_once_with(raw_docs)
     assert len(chunks) == 1
     assert chunks[0].page_content == "chunked content"
@@ -220,13 +290,19 @@ def test_chunk_documents_success(mock_splitter_class, mock_logger_fixture):
 def test_chunk_documents_empty_raw_docs(mock_st_warning, mock_logger_fixture):
     chunks = chunk_documents([])
     assert chunks == []
-    mock_st_warning.assert_called_once_with("No content found in the document to chunk.")
-    mock_logger_fixture.warning.assert_called_once_with("chunk_documents called with no raw documents.")
+    mock_st_warning.assert_called_once_with(
+        "No content found in the document to chunk."
+    )
+    mock_logger_fixture.warning.assert_called_once_with(
+        "chunk_documents called with no raw documents."
+    )
 
 
 @patch(RECURSIVE_SPLITTER_PATH)
 @patch(STREAMLIT_WARNING_PATH)
-def test_chunk_documents_no_processable_chunks(mock_st_warning, mock_splitter_class, mock_logger_fixture):
+def test_chunk_documents_no_processable_chunks(
+    mock_st_warning, mock_splitter_class, mock_logger_fixture
+):
     mock_splitter_instance = MagicMock()
     mock_splitter_instance.split_documents.return_value = []
     mock_splitter_class.return_value = mock_splitter_instance
@@ -235,13 +311,19 @@ def test_chunk_documents_no_processable_chunks(mock_st_warning, mock_splitter_cl
     chunks = chunk_documents(raw_docs)
 
     assert chunks == []
-    mock_st_warning.assert_called_once_with("Document chunking resulted in no processable text chunks. The document might be valid but contain no extractable text after initial processing, or the text is too short.")
-    mock_logger_fixture.warning.assert_called_once_with("Document chunking resulted in no processable text chunks.")
+    mock_st_warning.assert_called_once_with(
+        "Document chunking resulted in no processable text chunks. The document might be valid but contain no extractable text after initial processing, or the text is too short."
+    )
+    mock_logger_fixture.warning.assert_called_once_with(
+        "Document chunking resulted in no processable text chunks."
+    )
 
 
 @patch(RECURSIVE_SPLITTER_PATH, side_effect=Exception("Chunking failed"))
 @patch(STREAMLIT_ERROR_PATH)
-def test_chunk_documents_exception(mock_st_error, mock_splitter_class_exception, mock_logger_fixture):
+def test_chunk_documents_exception(
+    mock_st_error, mock_splitter_class_exception, mock_logger_fixture
+):
     raw_docs = [LangchainDocument(page_content="Some content")]
     chunks = chunk_documents(raw_docs)
 
@@ -252,30 +334,44 @@ def test_chunk_documents_exception(mock_st_error, mock_splitter_class_exception,
 
 # --- Tests for index_documents (from previous step, confirmed good) ---
 
-@patch('core.document_processing.st.session_state', new_callable=MagicMock)
+
+@patch("core.document_processing.st.session_state", new_callable=MagicMock)
 def test_index_documents_success(mock_session_state, mock_logger_fixture):
     mock_vector_db_instance = MagicMock()
     mock_session_state.DOCUMENT_VECTOR_DB = mock_vector_db_instance
 
-    mock_chunks = [LangchainDocument(page_content="chunk1"), LangchainDocument(page_content="chunk2")]
+    mock_chunks = [
+        LangchainDocument(page_content="chunk1"),
+        LangchainDocument(page_content="chunk2"),
+    ]
     index_documents(mock_chunks)
 
     mock_vector_db_instance.add_documents.assert_called_once_with(mock_chunks)
     assert mock_session_state.document_processed is True
-    mock_logger_fixture.info.assert_any_call(f"Indexing {len(mock_chunks)} document chunks.")
-    mock_logger_fixture.info.assert_any_call("Document chunks indexed successfully into vector store.")
+    mock_logger_fixture.info.assert_any_call(
+        f"Indexing {len(mock_chunks)} document chunks."
+    )
+    mock_logger_fixture.info.assert_any_call(
+        "Document chunks indexed successfully into vector store."
+    )
 
 
 @patch(STREAMLIT_WARNING_PATH)
 def test_index_documents_empty_chunks(mock_st_warning, mock_logger_fixture):
     index_documents([])
-    mock_st_warning.assert_called_once_with("No document chunks available to index. This may happen if the document was empty or text extraction failed.")
-    mock_logger_fixture.warning.assert_called_once_with("index_documents called with no chunks to index.")
+    mock_st_warning.assert_called_once_with(
+        "No document chunks available to index. This may happen if the document was empty or text extraction failed."
+    )
+    mock_logger_fixture.warning.assert_called_once_with(
+        "index_documents called with no chunks to index."
+    )
 
 
-@patch('core.document_processing.st.session_state', new_callable=MagicMock)
+@patch("core.document_processing.st.session_state", new_callable=MagicMock)
 @patch(STREAMLIT_ERROR_PATH)
-def test_index_documents_exception_on_add(mock_st_error, mock_session_state, mock_logger_fixture):
+def test_index_documents_exception_on_add(
+    mock_st_error, mock_session_state, mock_logger_fixture
+):
     mock_vector_db_instance = MagicMock()
     mock_vector_db_instance.add_documents.side_effect = Exception("DB Error")
     mock_session_state.DOCUMENT_VECTOR_DB = mock_vector_db_instance

--- a/tests/core/test_generation.py
+++ b/tests/core/test_generation.py
@@ -5,24 +5,22 @@ from unittest.mock import patch, MagicMock, ANY
 from langchain_core.documents import Document as LangchainDocument
 
 # Modules to test
-from core.generation import (
-    generate_answer,
-    generate_summary,
-    generate_keywords
-)
+from core.generation import generate_answer, generate_summary, generate_keywords
 
 # Import config to use its prompt templates, and logger for mocking
 from core import config
+
 # core.logger_config is not directly imported here, but we'll patch the logger instance
 # used within generation.py, which is 'core.generation.logger'
 
 # Paths for mocking
-STREAMLIT_ERROR_PATH = 'core.generation.st.error'
-STREAMLIT_WARNING_PATH = 'core.generation.st.warning'
-GENERATION_LOGGER_PATH = 'core.generation.logger'
-CHAT_PROMPT_TEMPLATE_PATH = 'core.generation.ChatPromptTemplate.from_template'
+STREAMLIT_ERROR_PATH = "core.generation.st.error"
+STREAMLIT_WARNING_PATH = "core.generation.st.warning"
+GENERATION_LOGGER_PATH = "core.generation.logger"
+CHAT_PROMPT_TEMPLATE_PATH = "core.generation.ChatPromptTemplate.from_template"
 
 # --- Fixtures ---
+
 
 @pytest.fixture
 def mock_llm():
@@ -30,9 +28,13 @@ def mock_llm():
     llm.invoke.return_value = "Mocked LLM response"
     return llm
 
+
 @pytest.fixture
 def mock_doc():
-    return lambda content, source="test_source": LangchainDocument(page_content=content, metadata={"source": source})
+    return lambda content, source="test_source": LangchainDocument(
+        page_content=content, metadata={"source": source}
+    )
+
 
 @pytest.fixture(autouse=True)
 def mock_logger_fixture():
@@ -40,10 +42,14 @@ def mock_logger_fixture():
     with patch(GENERATION_LOGGER_PATH) as mock_log:
         yield mock_log
 
+
 # --- Tests for generate_answer ---
 
+
 @patch(CHAT_PROMPT_TEMPLATE_PATH)
-def test_generate_answer_success_with_history(mock_from_template, mock_llm, mock_doc, mock_logger_fixture):
+def test_generate_answer_success_with_history(
+    mock_from_template, mock_llm, mock_doc, mock_logger_fixture
+):
     mock_template_instance = MagicMock()
     mock_chain_instance = MagicMock()
     # Simulate the LCEL chain: prompt | llm -> chain
@@ -64,13 +70,17 @@ def test_generate_answer_success_with_history(mock_from_template, mock_llm, mock
     mock_template_instance.__or__.assert_called_once_with(mock_llm)
 
     expected_doc_context = "X is Y.\n\nMore about X."
-    mock_chain_instance.invoke.assert_called_once_with({
-        "user_query": user_query,
-        "document_context": expected_doc_context,
-        "conversation_history": history
-    })
+    mock_chain_instance.invoke.assert_called_once_with(
+        {
+            "user_query": user_query,
+            "document_context": expected_doc_context,
+            "conversation_history": history,
+        }
+    )
     assert response == "Successful answer"
-    mock_logger_fixture.info.assert_any_call(f"Generating answer for query: '{user_query[:50]}...'")
+    mock_logger_fixture.info.assert_any_call(
+        f"Generating answer for query: '{user_query[:50]}...'"
+    )
     mock_logger_fixture.info.assert_any_call("Answer generated successfully.")
 
 
@@ -81,30 +91,51 @@ def test_generate_answer_llm_failure(mock_llm, mock_doc, mock_logger_fixture):
         response = generate_answer(mock_llm, "Query", [mock_doc("Content")], "History")
 
     assert "I'm sorry, but I encountered an error" in response
-    assert "(Details: LLM exploded)" in response # Check if detail is part of the returned user message
-    mock_st_error.assert_called_once() # This st.error is called from within generate_answer
+    assert (
+        "(Details: LLM exploded)" in response
+    )  # Check if detail is part of the returned user message
+    mock_st_error.assert_called_once()  # This st.error is called from within generate_answer
     mock_logger_fixture.exception.assert_called_once()
 
 
 def test_generate_answer_empty_query(mock_llm, mock_doc, mock_logger_fixture):
     response = generate_answer(mock_llm, "", [mock_doc("Content")])
-    assert response == "Your question is empty. Please type a question to get an answer."
-    mock_logger_fixture.warning.assert_called_once_with("generate_answer called with empty user_query.")
+    assert (
+        response == "Your question is empty. Please type a question to get an answer."
+    )
+    mock_logger_fixture.warning.assert_called_once_with(
+        "generate_answer called with empty user_query."
+    )
 
 
 def test_generate_answer_empty_context_docs(mock_llm, mock_logger_fixture):
     response = generate_answer(mock_llm, "Query", [])
-    assert response == "I couldn't find relevant information in the document to answer your query. Please try rephrasing your question or ensure the document contains the relevant topics."
-    mock_logger_fixture.warning.assert_called_once_with("generate_answer called with no context documents.")
+    assert (
+        response
+        == "I couldn't find relevant information in the document to answer your query. Please try rephrasing your question or ensure the document contains the relevant topics."
+    )
+    mock_logger_fixture.warning.assert_called_once_with(
+        "generate_answer called with no context documents."
+    )
 
 
-def test_generate_answer_context_docs_no_content(mock_llm, mock_doc, mock_logger_fixture):
-    response = generate_answer(mock_llm, "Query", [mock_doc("   ")]) # Content is whitespace
-    assert response == "The relevant sections found in the document appear to be empty. Cannot generate an answer."
-    mock_logger_fixture.warning.assert_called_once_with("Context text for answer generation is empty after joining docs.")
+def test_generate_answer_context_docs_no_content(
+    mock_llm, mock_doc, mock_logger_fixture
+):
+    response = generate_answer(
+        mock_llm, "Query", [mock_doc("   ")]
+    )  # Content is whitespace
+    assert (
+        response
+        == "The relevant sections found in the document appear to be empty. Cannot generate an answer."
+    )
+    mock_logger_fixture.warning.assert_called_once_with(
+        "Context text for answer generation is empty after joining docs."
+    )
 
 
 # --- Tests for generate_summary ---
+
 
 @patch(CHAT_PROMPT_TEMPLATE_PATH)
 def test_generate_summary_success(mock_from_template, mock_llm, mock_logger_fixture):
@@ -140,20 +171,31 @@ def test_generate_summary_llm_failure(mock_llm, mock_logger_fixture):
 def test_generate_summary_empty_input(mock_st_warning, mock_llm, mock_logger_fixture):
     summary = generate_summary(mock_llm, "   ")
     assert summary is None
-    mock_st_warning.assert_called_once_with("Document content is empty or contains only whitespace. Cannot generate summary.")
-    mock_logger_fixture.warning.assert_called_once_with("generate_summary called with empty document text.")
+    mock_st_warning.assert_called_once_with(
+        "Document content is empty or contains only whitespace. Cannot generate summary."
+    )
+    mock_logger_fixture.warning.assert_called_once_with(
+        "generate_summary called with empty document text."
+    )
 
 
 @patch(STREAMLIT_WARNING_PATH)
-def test_generate_summary_llm_returns_empty(mock_st_warning, mock_llm, mock_logger_fixture):
+def test_generate_summary_llm_returns_empty(
+    mock_st_warning, mock_llm, mock_logger_fixture
+):
     mock_llm.invoke.return_value = "   "
     summary = generate_summary(mock_llm, "Some text")
     assert summary is None
-    mock_st_warning.assert_called_once_with("The AI model returned an empty summary. The document might be too short or lack clear content for summarization.")
-    mock_logger_fixture.warning.assert_called_once_with("AI model returned an empty summary.")
+    mock_st_warning.assert_called_once_with(
+        "The AI model returned an empty summary. The document might be too short or lack clear content for summarization."
+    )
+    mock_logger_fixture.warning.assert_called_once_with(
+        "AI model returned an empty summary."
+    )
 
 
 # --- Tests for generate_keywords ---
+
 
 @patch(CHAT_PROMPT_TEMPLATE_PATH)
 def test_generate_keywords_success(mock_from_template, mock_llm, mock_logger_fixture):
@@ -166,7 +208,9 @@ def test_generate_keywords_success(mock_from_template, mock_llm, mock_logger_fix
     text = "This is a document about keywords."
     keywords = generate_keywords(mock_llm, text)
 
-    mock_from_template.assert_called_once_with(config.KEYWORD_EXTRACTION_PROMPT_TEMPLATE)
+    mock_from_template.assert_called_once_with(
+        config.KEYWORD_EXTRACTION_PROMPT_TEMPLATE
+    )
     mock_template_instance.__or__.assert_called_once_with(mock_llm)
     mock_chain_instance.invoke.assert_called_once_with({"document_text": text})
     assert keywords == "keyword1, keyword2"
@@ -189,14 +233,24 @@ def test_generate_keywords_llm_failure(mock_llm, mock_logger_fixture):
 def test_generate_keywords_empty_input(mock_st_warning, mock_llm, mock_logger_fixture):
     keywords = generate_keywords(mock_llm, "")
     assert keywords is None
-    mock_st_warning.assert_called_once_with("Document content is empty or contains only whitespace. Cannot extract keywords.")
-    mock_logger_fixture.warning.assert_called_once_with("generate_keywords called with empty document text.")
+    mock_st_warning.assert_called_once_with(
+        "Document content is empty or contains only whitespace. Cannot extract keywords."
+    )
+    mock_logger_fixture.warning.assert_called_once_with(
+        "generate_keywords called with empty document text."
+    )
 
 
 @patch(STREAMLIT_WARNING_PATH)
-def test_generate_keywords_llm_returns_empty(mock_st_warning, mock_llm, mock_logger_fixture):
+def test_generate_keywords_llm_returns_empty(
+    mock_st_warning, mock_llm, mock_logger_fixture
+):
     mock_llm.invoke.return_value = ""
     keywords = generate_keywords(mock_llm, "Some text")
     assert keywords is None
-    mock_st_warning.assert_called_once_with("The AI model returned no keywords. The document might be too short or lack distinct terms.")
-    mock_logger_fixture.warning.assert_called_once_with("AI model returned no keywords.")
+    mock_st_warning.assert_called_once_with(
+        "The AI model returned no keywords. The document might be too short or lack distinct terms."
+    )
+    mock_logger_fixture.warning.assert_called_once_with(
+        "AI model returned no keywords."
+    )

--- a/tests/core/test_model_loader.py
+++ b/tests/core/test_model_loader.py
@@ -2,7 +2,11 @@ import pytest
 from unittest.mock import patch, MagicMock, ANY
 
 # Modules to test
-from core.model_loader import get_embedding_model, get_language_model, get_reranker_model
+from core.model_loader import (
+    get_embedding_model,
+    get_language_model,
+    get_reranker_model,
+)
 
 # To allow modifying config values for tests
 from core import config
@@ -11,60 +15,80 @@ from core import config
 import requests
 
 # Paths for mocking external dependencies as they are seen by 'core.model_loader'
-OLLAMA_EMBEDDINGS_PATH = 'core.model_loader.OllamaEmbeddings'
-OLLAMA_LLM_PATH = 'core.model_loader.OllamaLLM'
-CROSS_ENCODER_PATH = 'core.model_loader.CrossEncoder'
-STREAMLIT_ERROR_PATH = 'core.model_loader.st.error' # st.error is used directly in model_loader
-MODEL_LOADER_LOGGER_PATH = 'core.model_loader.logger' # Path to the logger instance in model_loader.py
+OLLAMA_EMBEDDINGS_PATH = "core.model_loader.OllamaEmbeddings"
+OLLAMA_LLM_PATH = "core.model_loader.OllamaLLM"
+CROSS_ENCODER_PATH = "core.model_loader.CrossEncoder"
+STREAMLIT_ERROR_PATH = (
+    "core.model_loader.st.error"  # st.error is used directly in model_loader
+)
+MODEL_LOADER_LOGGER_PATH = (
+    "core.model_loader.logger"  # Path to the logger instance in model_loader.py
+)
+
 
 # Fixture to automatically clear caches for model loader functions after each test.
 # This is important because @st.cache_resource memoizes results.
 @pytest.fixture(autouse=True)
 def clear_model_loader_caches():
-    yield # Run the test
+    yield  # Run the test
     # Check if .clear_cache attribute exists before calling,
     # as it's added by @st.cache_resource at runtime.
-    if hasattr(get_embedding_model, 'clear_cache'):
+    if hasattr(get_embedding_model, "clear_cache"):
         get_embedding_model.clear_cache()
-    if hasattr(get_language_model, 'clear_cache'):
+    if hasattr(get_language_model, "clear_cache"):
         get_language_model.clear_cache()
-    if hasattr(get_reranker_model, 'clear_cache'):
+    if hasattr(get_reranker_model, "clear_cache"):
         get_reranker_model.clear_cache()
+
 
 # --- Test for get_embedding_model ---
 
+
 @patch(OLLAMA_EMBEDDINGS_PATH)
 @patch(STREAMLIT_ERROR_PATH)
 @patch(MODEL_LOADER_LOGGER_PATH)
-def test_get_embedding_model_success(mock_logger, mock_st_error, mock_ollama_embeddings_class):
+def test_get_embedding_model_success(
+    mock_logger, mock_st_error, mock_ollama_embeddings_class
+):
     mock_embedding_instance = MagicMock()
     mock_ollama_embeddings_class.return_value = mock_embedding_instance
 
-    with patch.object(config, 'OLLAMA_EMBEDDING_MODEL_NAME', 'test-embed-model'), \
-         patch.object(config, 'OLLAMA_BASE_URL', 'http://test-host:11434'):
+    with patch.object(
+        config, "OLLAMA_EMBEDDING_MODEL_NAME", "test-embed-model"
+    ), patch.object(config, "OLLAMA_BASE_URL", "http://test-host:11434"):
 
-        if hasattr(get_embedding_model, 'clear_cache'): get_embedding_model.clear_cache()
+        if hasattr(get_embedding_model, "clear_cache"):
+            get_embedding_model.clear_cache()
         model = get_embedding_model()
 
     mock_ollama_embeddings_class.assert_called_once_with(
-        model='test-embed-model',
-        base_url='http://test-host:11434'
+        model="test-embed-model", base_url="http://test-host:11434"
     )
     assert model == mock_embedding_instance
     mock_st_error.assert_not_called()
-    mock_logger.info.assert_any_call("Attempting to load Embedding Model: test-embed-model from: http://test-host:11434")
-    mock_logger.info.assert_any_call("Embedding Model test-embed-model loaded successfully.")
+    mock_logger.info.assert_any_call(
+        "Attempting to load Embedding Model: test-embed-model from: http://test-host:11434"
+    )
+    mock_logger.info.assert_any_call(
+        "Embedding Model test-embed-model loaded successfully."
+    )
 
 
 @patch(OLLAMA_EMBEDDINGS_PATH)
 @patch(STREAMLIT_ERROR_PATH)
 @patch(MODEL_LOADER_LOGGER_PATH)
-def test_get_embedding_model_connection_error(mock_logger, mock_st_error, mock_ollama_embeddings_class):
-    mock_ollama_embeddings_class.side_effect = requests.exceptions.ConnectionError("Test connection error")
-    if hasattr(get_embedding_model, 'clear_cache'): get_embedding_model.clear_cache()
+def test_get_embedding_model_connection_error(
+    mock_logger, mock_st_error, mock_ollama_embeddings_class
+):
+    mock_ollama_embeddings_class.side_effect = requests.exceptions.ConnectionError(
+        "Test connection error"
+    )
+    if hasattr(get_embedding_model, "clear_cache"):
+        get_embedding_model.clear_cache()
 
-    with patch.object(config, 'OLLAMA_BASE_URL', 'http://nonexistent:11434'), \
-         patch.object(config, 'OLLAMA_EMBEDDING_MODEL_NAME', 'test-embed-model'):
+    with patch.object(
+        config, "OLLAMA_BASE_URL", "http://nonexistent:11434"
+    ), patch.object(config, "OLLAMA_EMBEDDING_MODEL_NAME", "test-embed-model"):
         model = get_embedding_model()
 
     assert model is None
@@ -78,21 +102,28 @@ def test_get_embedding_model_connection_error(mock_logger, mock_st_error, mock_o
 @patch(OLLAMA_EMBEDDINGS_PATH)
 @patch(STREAMLIT_ERROR_PATH)
 @patch(MODEL_LOADER_LOGGER_PATH)
-def test_get_embedding_model_other_exception(mock_logger, mock_st_error, mock_ollama_embeddings_class):
+def test_get_embedding_model_other_exception(
+    mock_logger, mock_st_error, mock_ollama_embeddings_class
+):
     mock_ollama_embeddings_class.side_effect = Exception("Some other error")
-    if hasattr(get_embedding_model, 'clear_cache'): get_embedding_model.clear_cache()
+    if hasattr(get_embedding_model, "clear_cache"):
+        get_embedding_model.clear_cache()
 
-    with patch.object(config, 'OLLAMA_EMBEDDING_MODEL_NAME', 'test-embed-model'):
+    with patch.object(config, "OLLAMA_EMBEDDING_MODEL_NAME", "test-embed-model"):
         model = get_embedding_model()
 
     assert model is None
     mock_st_error.assert_called_once()
     args, _ = mock_st_error.call_args
-    assert "An unexpected error occurred while loading the Embedding Model (test-embed-model)" in args[0]
+    assert (
+        "An unexpected error occurred while loading the Embedding Model (test-embed-model)"
+        in args[0]
+    )
     mock_logger.exception.assert_called_once_with(ANY)
 
 
 # --- Test for get_language_model ---
+
 
 @patch(OLLAMA_LLM_PATH)
 @patch(STREAMLIT_ERROR_PATH)
@@ -100,32 +131,43 @@ def test_get_embedding_model_other_exception(mock_logger, mock_st_error, mock_ol
 def test_get_language_model_success(mock_logger, mock_st_error, mock_ollama_llm_class):
     mock_llm_instance = MagicMock()
     mock_ollama_llm_class.return_value = mock_llm_instance
-    if hasattr(get_language_model, 'clear_cache'): get_language_model.clear_cache()
+    if hasattr(get_language_model, "clear_cache"):
+        get_language_model.clear_cache()
 
-    with patch.object(config, 'OLLAMA_LLM_NAME', 'test-llm-model'), \
-         patch.object(config, 'OLLAMA_BASE_URL', 'http://test-llm-host:11434'):
+    with patch.object(config, "OLLAMA_LLM_NAME", "test-llm-model"), patch.object(
+        config, "OLLAMA_BASE_URL", "http://test-llm-host:11434"
+    ):
 
         model = get_language_model()
 
     mock_ollama_llm_class.assert_called_once_with(
-        model='test-llm-model',
-        base_url='http://test-llm-host:11434'
+        model="test-llm-model", base_url="http://test-llm-host:11434"
     )
     assert model == mock_llm_instance
     mock_st_error.assert_not_called()
-    mock_logger.info.assert_any_call("Attempting to load Language Model: test-llm-model from: http://test-llm-host:11434")
-    mock_logger.info.assert_any_call("Language Model test-llm-model loaded successfully.")
+    mock_logger.info.assert_any_call(
+        "Attempting to load Language Model: test-llm-model from: http://test-llm-host:11434"
+    )
+    mock_logger.info.assert_any_call(
+        "Language Model test-llm-model loaded successfully."
+    )
 
 
 @patch(OLLAMA_LLM_PATH)
 @patch(STREAMLIT_ERROR_PATH)
 @patch(MODEL_LOADER_LOGGER_PATH)
-def test_get_language_model_connection_error(mock_logger, mock_st_error, mock_ollama_llm_class):
-    mock_ollama_llm_class.side_effect = requests.exceptions.ConnectionError("Test LLM connection error")
-    if hasattr(get_language_model, 'clear_cache'): get_language_model.clear_cache()
+def test_get_language_model_connection_error(
+    mock_logger, mock_st_error, mock_ollama_llm_class
+):
+    mock_ollama_llm_class.side_effect = requests.exceptions.ConnectionError(
+        "Test LLM connection error"
+    )
+    if hasattr(get_language_model, "clear_cache"):
+        get_language_model.clear_cache()
 
-    with patch.object(config, 'OLLAMA_BASE_URL', 'http://nonexistent-llm:11434'), \
-         patch.object(config, 'OLLAMA_LLM_NAME', 'test-llm-model'):
+    with patch.object(
+        config, "OLLAMA_BASE_URL", "http://nonexistent-llm:11434"
+    ), patch.object(config, "OLLAMA_LLM_NAME", "test-llm-model"):
         model = get_language_model()
 
     assert model is None
@@ -139,48 +181,65 @@ def test_get_language_model_connection_error(mock_logger, mock_st_error, mock_ol
 @patch(OLLAMA_LLM_PATH)
 @patch(STREAMLIT_ERROR_PATH)
 @patch(MODEL_LOADER_LOGGER_PATH)
-def test_get_language_model_other_exception(mock_logger, mock_st_error, mock_ollama_llm_class):
+def test_get_language_model_other_exception(
+    mock_logger, mock_st_error, mock_ollama_llm_class
+):
     mock_ollama_llm_class.side_effect = Exception("Some other LLM error")
-    if hasattr(get_language_model, 'clear_cache'): get_language_model.clear_cache()
+    if hasattr(get_language_model, "clear_cache"):
+        get_language_model.clear_cache()
 
-    with patch.object(config, 'OLLAMA_LLM_NAME', 'test-llm-model'):
+    with patch.object(config, "OLLAMA_LLM_NAME", "test-llm-model"):
         model = get_language_model()
 
     assert model is None
     mock_st_error.assert_called_once()
     args, _ = mock_st_error.call_args
-    assert "An unexpected error occurred while loading the Language Model (test-llm-model)" in args[0]
+    assert (
+        "An unexpected error occurred while loading the Language Model (test-llm-model)"
+        in args[0]
+    )
     mock_logger.exception.assert_called_once_with(ANY)
 
 
 # --- Test for get_reranker_model ---
 
+
 @patch(CROSS_ENCODER_PATH)
 @patch(STREAMLIT_ERROR_PATH)
 @patch(MODEL_LOADER_LOGGER_PATH)
-def test_get_reranker_model_success(mock_logger, mock_st_error, mock_cross_encoder_class):
+def test_get_reranker_model_success(
+    mock_logger, mock_st_error, mock_cross_encoder_class
+):
     mock_reranker_instance = MagicMock()
     mock_cross_encoder_class.return_value = mock_reranker_instance
-    if hasattr(get_reranker_model, 'clear_cache'): get_reranker_model.clear_cache()
+    if hasattr(get_reranker_model, "clear_cache"):
+        get_reranker_model.clear_cache()
 
-    with patch.object(config, 'RERANKER_MODEL_NAME', 'test-reranker-model'):
+    with patch.object(config, "RERANKER_MODEL_NAME", "test-reranker-model"):
         model = get_reranker_model()
 
-    mock_cross_encoder_class.assert_called_once_with('test-reranker-model')
+    mock_cross_encoder_class.assert_called_once_with("test-reranker-model")
     assert model == mock_reranker_instance
     mock_st_error.assert_not_called()
-    mock_logger.info.assert_any_call("Attempting to load CrossEncoder model: test-reranker-model")
-    mock_logger.info.assert_any_call("CrossEncoder model test-reranker-model loaded successfully.")
+    mock_logger.info.assert_any_call(
+        "Attempting to load CrossEncoder model: test-reranker-model"
+    )
+    mock_logger.info.assert_any_call(
+        "CrossEncoder model test-reranker-model loaded successfully."
+    )
 
 
 @patch(CROSS_ENCODER_PATH)
 @patch(STREAMLIT_ERROR_PATH)
 @patch(MODEL_LOADER_LOGGER_PATH)
-def test_get_reranker_model_exception(mock_logger, mock_st_error, mock_cross_encoder_class):
+def test_get_reranker_model_exception(
+    mock_logger, mock_st_error, mock_cross_encoder_class
+):
     mock_cross_encoder_class.side_effect = Exception("Reranker load error")
-    if hasattr(get_reranker_model, 'clear_cache'): get_reranker_model.clear_cache()
+    if hasattr(get_reranker_model, "clear_cache"):
+        get_reranker_model.clear_cache()
 
-    with patch.object(config, 'RERANKER_MODEL_NAME', 'failing-reranker-model'):
+    with patch.object(config, "RERANKER_MODEL_NAME", "failing-reranker-model"):
         model = get_reranker_model()
 
     assert model is None

--- a/tests/core/test_search_pipeline.py
+++ b/tests/core/test_search_pipeline.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, MagicMock, ANY
 
 # Import LangchainDocument for creating test data
 from langchain_core.documents import Document as LangchainDocument
+
 # Import for type hinting if needed, though mocks replace actual instances
 from rank_bm25 import BM25Okapi
 from sentence_transformers import CrossEncoder
@@ -12,22 +13,26 @@ from sentence_transformers import CrossEncoder
 from core.search_pipeline import (
     find_related_documents,
     combine_results_rrf,
-    rerank_documents
+    rerank_documents,
 )
 
 # Import config to use/mock its values, and logger for mocking
 from core import config
 
 # Paths for mocking
-STREAMLIT_ERROR_PATH = 'core.search_pipeline.st.error'
-STREAMLIT_WARNING_PATH = 'core.search_pipeline.st.warning'
-SEARCH_PIPELINE_LOGGER_PATH = 'core.search_pipeline.logger'
+STREAMLIT_ERROR_PATH = "core.search_pipeline.st.error"
+STREAMLIT_WARNING_PATH = "core.search_pipeline.st.warning"
+SEARCH_PIPELINE_LOGGER_PATH = "core.search_pipeline.logger"
 
 # --- Fixtures ---
 
+
 @pytest.fixture
-def mock_doc_factory(): # Renamed to avoid conflict if mock_doc is used as a specific instance
-    return lambda content, source="test_source": LangchainDocument(page_content=content, metadata={"source": source})
+def mock_doc_factory():  # Renamed to avoid conflict if mock_doc is used as a specific instance
+    return lambda content, source="test_source": LangchainDocument(
+        page_content=content, metadata={"source": source}
+    )
+
 
 @pytest.fixture
 def mock_vector_db():
@@ -35,17 +40,20 @@ def mock_vector_db():
     db.similarity_search.return_value = []
     return db
 
+
 @pytest.fixture
 def mock_bm25_index():
-    index = MagicMock(spec=BM25Okapi) # Use spec for better mocking
+    index = MagicMock(spec=BM25Okapi)  # Use spec for better mocking
     index.get_scores.return_value = []
     return index
 
+
 @pytest.fixture
-def mock_cross_encoder(): # Renamed for clarity
+def mock_cross_encoder():  # Renamed for clarity
     model = MagicMock(spec=CrossEncoder)
     model.predict.return_value = []
     return model
+
 
 @pytest.fixture(autouse=True)
 def mock_logger_fixture():
@@ -53,23 +61,43 @@ def mock_logger_fixture():
     with patch(SEARCH_PIPELINE_LOGGER_PATH) as mock_log:
         yield mock_log
 
+
 # --- Tests for find_related_documents (incorporating tests from test_rag_deep.py) ---
 
-def test_find_related_documents_empty_query(mock_vector_db, mock_bm25_index, mock_logger_fixture):
+
+def test_find_related_documents_empty_query(
+    mock_vector_db, mock_bm25_index, mock_logger_fixture
+):
     with patch(STREAMLIT_WARNING_PATH) as mock_st_warning:
         results = find_related_documents("", mock_vector_db, mock_bm25_index, [], True)
     assert results == {"semantic_results": [], "bm25_results": []}
-    mock_st_warning.assert_called_once_with("Search query is empty. Please enter a query to find related documents.")
-    mock_logger_fixture.warning.assert_called_with("find_related_documents called with empty query.")
+    mock_st_warning.assert_called_once_with(
+        "Search query is empty. Please enter a query to find related documents."
+    )
+    mock_logger_fixture.warning.assert_called_with(
+        "find_related_documents called with empty query."
+    )
 
-def test_find_related_documents_document_not_processed(mock_vector_db, mock_bm25_index, mock_logger_fixture):
+
+def test_find_related_documents_document_not_processed(
+    mock_vector_db, mock_bm25_index, mock_logger_fixture
+):
     with patch(STREAMLIT_WARNING_PATH) as mock_st_warning:
-        results = find_related_documents("query", mock_vector_db, mock_bm25_index, [], False)
+        results = find_related_documents(
+            "query", mock_vector_db, mock_bm25_index, [], False
+        )
     assert results == {"semantic_results": [], "bm25_results": []}
-    mock_st_warning.assert_called_once_with("No document has been processed yet. Please upload and process a document before searching.")
-    mock_logger_fixture.warning.assert_called_with("find_related_documents called but no document processed.")
+    mock_st_warning.assert_called_once_with(
+        "No document has been processed yet. Please upload and process a document before searching."
+    )
+    mock_logger_fixture.warning.assert_called_with(
+        "find_related_documents called but no document processed."
+    )
 
-def test_find_related_documents_success_both_searches(mock_doc_factory, mock_vector_db, mock_bm25_index, mock_logger_fixture):
+
+def test_find_related_documents_success_both_searches(
+    mock_doc_factory, mock_vector_db, mock_bm25_index, mock_logger_fixture
+):
     semantic_result = [mock_doc_factory("semantic content")]
     bm25_result_doc = mock_doc_factory("bm25 content")
 
@@ -77,17 +105,26 @@ def test_find_related_documents_success_both_searches(mock_doc_factory, mock_vec
     mock_bm25_index.get_scores.return_value = [0.5]
     bm25_corpus_chunks = [bm25_result_doc]
 
-    with patch.object(config, 'K_SEMANTIC', 1), patch.object(config, 'K_BM25', 1):
-        results = find_related_documents("query", mock_vector_db, mock_bm25_index, bm25_corpus_chunks, True)
+    with patch.object(config, "K_SEMANTIC", 1), patch.object(config, "K_BM25", 1):
+        results = find_related_documents(
+            "query", mock_vector_db, mock_bm25_index, bm25_corpus_chunks, True
+        )
 
     mock_vector_db.similarity_search.assert_called_once_with("query", k=1)
-    mock_bm25_index.get_scores.assert_called_once_with(["query"]) # Assuming query is tokenized to ["query"]
+    mock_bm25_index.get_scores.assert_called_once_with(
+        ["query"]
+    )  # Assuming query is tokenized to ["query"]
     assert results["semantic_results"] == semantic_result
     assert results["bm25_results"] == [bm25_result_doc]
     mock_logger_fixture.info.assert_any_call("Semantic search found 1 results.")
-    mock_logger_fixture.info.assert_any_call("BM25 search found 1 results with positive scores.")
+    mock_logger_fixture.info.assert_any_call(
+        "BM25 search found 1 results with positive scores."
+    )
 
-def test_find_related_documents_only_semantic(mock_doc_factory, mock_vector_db, mock_logger_fixture):
+
+def test_find_related_documents_only_semantic(
+    mock_doc_factory, mock_vector_db, mock_logger_fixture
+):
     semantic_doc1 = mock_doc_factory("semantic only")
     mock_vector_db.similarity_search.return_value = [semantic_doc1]
 
@@ -96,42 +133,68 @@ def test_find_related_documents_only_semantic(mock_doc_factory, mock_vector_db, 
     assert len(results["semantic_results"]) == 1
     assert results["semantic_results"][0].page_content == "semantic only"
     assert len(results["bm25_results"]) == 0
-    mock_logger_fixture.info.assert_any_call("BM25 index not available. Skipping BM25 search.")
+    mock_logger_fixture.info.assert_any_call(
+        "BM25 index not available. Skipping BM25 search."
+    )
 
-def test_find_related_documents_only_bm25(mock_doc_factory, mock_vector_db, mock_bm25_index, mock_logger_fixture):
-    mock_vector_db.similarity_search.return_value = [] # No semantic results
+
+def test_find_related_documents_only_bm25(
+    mock_doc_factory, mock_vector_db, mock_bm25_index, mock_logger_fixture
+):
+    mock_vector_db.similarity_search.return_value = []  # No semantic results
 
     bm25_doc1 = mock_doc_factory("bm25 only")
     mock_bm25_index.get_scores.return_value = [0.9]
     bm25_corpus_chunks = [bm25_doc1]
 
-    results = find_related_documents("test query", mock_vector_db, mock_bm25_index, bm25_corpus_chunks, True)
+    results = find_related_documents(
+        "test query", mock_vector_db, mock_bm25_index, bm25_corpus_chunks, True
+    )
     assert len(results["semantic_results"]) == 0
     assert len(results["bm25_results"]) == 1
     assert results["bm25_results"][0].page_content == "bm25 only"
 
-def test_find_related_documents_no_results(mock_vector_db, mock_bm25_index, mock_logger_fixture):
+
+def test_find_related_documents_no_results(
+    mock_vector_db, mock_bm25_index, mock_logger_fixture
+):
     mock_vector_db.similarity_search.return_value = []
     mock_bm25_index.get_scores.return_value = []
     bm25_corpus_chunks = [mock_doc_factory("doc1"), mock_doc_factory("doc2")]
 
-    results = find_related_documents("query for no results", mock_vector_db, mock_bm25_index, bm25_corpus_chunks, True)
+    results = find_related_documents(
+        "query for no results",
+        mock_vector_db,
+        mock_bm25_index,
+        bm25_corpus_chunks,
+        True,
+    )
     assert len(results["semantic_results"]) == 0
     assert len(results["bm25_results"]) == 0
 
-def test_find_related_documents_semantic_error(mock_vector_db, mock_bm25_index, mock_logger_fixture):
+
+def test_find_related_documents_semantic_error(
+    mock_vector_db, mock_bm25_index, mock_logger_fixture
+):
     mock_vector_db.similarity_search.side_effect = Exception("Semantic DB error")
     with patch(STREAMLIT_ERROR_PATH) as mock_st_error:
-        results = find_related_documents("query", mock_vector_db, mock_bm25_index, [], True)
+        results = find_related_documents(
+            "query", mock_vector_db, mock_bm25_index, [], True
+        )
     assert results["semantic_results"] == []
     mock_st_error.assert_called_once()
     mock_logger_fixture.exception.assert_called_once()
 
-def test_find_related_documents_bm25_error(mock_vector_db, mock_bm25_index, mock_logger_fixture):
+
+def test_find_related_documents_bm25_error(
+    mock_vector_db, mock_bm25_index, mock_logger_fixture
+):
     mock_bm25_index.get_scores.side_effect = Exception("BM25 index error")
     bm25_corpus_chunks = [MagicMock()]
     with patch(STREAMLIT_ERROR_PATH) as mock_st_error:
-        results = find_related_documents("query", mock_vector_db, mock_bm25_index, bm25_corpus_chunks, True)
+        results = find_related_documents(
+            "query", mock_vector_db, mock_bm25_index, bm25_corpus_chunks, True
+        )
     assert results["bm25_results"] == []
     mock_st_error.assert_called_once()
     mock_logger_fixture.exception.assert_called_once()
@@ -139,15 +202,21 @@ def test_find_related_documents_bm25_error(mock_vector_db, mock_bm25_index, mock
 
 # --- Tests for combine_results_rrf (incorporating tests from test_rag_deep.py) ---
 
+
 def test_combine_results_rrf_no_overlap(mock_doc_factory, mock_logger_fixture):
     docS1 = mock_doc_factory("semantic doc 1")
     docS2 = mock_doc_factory("semantic doc 2")
     docB1 = mock_doc_factory("bm25 doc 1")
     docB2 = mock_doc_factory("bm25 doc 2")
 
-    search_results = {"semantic_results": [docS1, docS2], "bm25_results": [docB1, docB2]}
+    search_results = {
+        "semantic_results": [docS1, docS2],
+        "bm25_results": [docB1, docB2],
+    }
 
-    with patch.object(config, 'K_RRF_PARAM', 60): # Use actual default or a testable one
+    with patch.object(
+        config, "K_RRF_PARAM", 60
+    ):  # Use actual default or a testable one
         combined = combine_results_rrf(search_results)
 
     assert len(combined) == 4
@@ -167,13 +236,14 @@ def test_combine_results_rrf_full_overlap(mock_doc_factory, mock_logger_fixture)
 
     search_results_deterministic = {
         "semantic_results": [doc1, doc2],
-        "bm25_results": [doc1, doc2]
+        "bm25_results": [doc1, doc2],
     }
-    with patch.object(config, 'K_RRF_PARAM', 60):
+    with patch.object(config, "K_RRF_PARAM", 60):
         combined_det = combine_results_rrf(search_results_deterministic)
     assert len(combined_det) == 2
     assert combined_det[0] == doc1
     assert combined_det[1] == doc2
+
 
 def test_combine_results_rrf_partial_overlap(mock_doc_factory, mock_logger_fixture):
     doc1 = mock_doc_factory("doc1 common")
@@ -181,7 +251,7 @@ def test_combine_results_rrf_partial_overlap(mock_doc_factory, mock_logger_fixtu
     docB2 = mock_doc_factory("docB2 bm25 only")
 
     search_results = {"semantic_results": [doc1, docS2], "bm25_results": [doc1, docB2]}
-    with patch.object(config, 'K_RRF_PARAM', 1): # For predictable scoring
+    with patch.object(config, "K_RRF_PARAM", 1):  # For predictable scoring
         combined = combine_results_rrf(search_results)
 
     assert len(combined) == 3
@@ -189,26 +259,42 @@ def test_combine_results_rrf_partial_overlap(mock_doc_factory, mock_logger_fixtu
     assert docS2 in combined[1:]
     assert docB2 in combined[1:]
 
+
 def test_combine_results_rrf_empty_lists(mock_doc_factory, mock_logger_fixture):
     docS1 = mock_doc_factory("semantic doc 1")
     docB1 = mock_doc_factory("bm25 doc 1")
 
-    combined_both_empty = combine_results_rrf({"semantic_results": [], "bm25_results": []})
+    combined_both_empty = combine_results_rrf(
+        {"semantic_results": [], "bm25_results": []}
+    )
     assert len(combined_both_empty) == 0
 
-    combined_sem_empty = combine_results_rrf({"semantic_results": [], "bm25_results": [docB1]})
+    combined_sem_empty = combine_results_rrf(
+        {"semantic_results": [], "bm25_results": [docB1]}
+    )
     assert len(combined_sem_empty) == 1 and combined_sem_empty[0] == docB1
 
-    combined_bm25_empty = combine_results_rrf({"semantic_results": [docS1], "bm25_results": []})
+    combined_bm25_empty = combine_results_rrf(
+        {"semantic_results": [docS1], "bm25_results": []}
+    )
     assert len(combined_bm25_empty) == 1 and combined_bm25_empty[0] == docS1
 
+
 def test_combine_results_rrf_varying_ranks_and_k(mock_doc_factory, mock_logger_fixture):
-    docA, docB, docC, docD = mock_doc_factory("A"), mock_doc_factory("B"), mock_doc_factory("C"), mock_doc_factory("D")
-    search_results = {"semantic_results": [docA, docB, docC], "bm25_results": [docB, docC, docA, docD]}
+    docA, docB, docC, docD = (
+        mock_doc_factory("A"),
+        mock_doc_factory("B"),
+        mock_doc_factory("C"),
+        mock_doc_factory("D"),
+    )
+    search_results = {
+        "semantic_results": [docA, docB, docC],
+        "bm25_results": [docB, docC, docA, docD],
+    }
 
     # Patch K_RRF_PARAM directly in the config module for this test
-    with patch.object(config, 'K_RRF_PARAM', 2):
-      combined = combine_results_rrf(search_results)
+    with patch.object(config, "K_RRF_PARAM", 2):
+        combined = combine_results_rrf(search_results)
 
     assert len(combined) == 4
     assert combined[0] == docB
@@ -216,29 +302,60 @@ def test_combine_results_rrf_varying_ranks_and_k(mock_doc_factory, mock_logger_f
     assert combined[2] == docC
     assert combined[3] == docD
 
+
 # --- Tests for rerank_documents (incorporating tests from test_rag_deep.py) ---
 
-@pytest.mark.parametrize("scores, initial_contents, expected_order_indices, top_n_config_key", [
-    ([0.1, 0.9, 0.5], ["doc1", "doc2", "doc3"], [1, 2, 0], 'FINAL_TOP_N_FOR_CONTEXT'),
-    ([0.9, 0.5, 0.1], ["doc1", "doc2", "doc3"], [0, 1, 2], 'FINAL_TOP_N_FOR_CONTEXT'),
-    ([0.1, 0.9, 0.5], ["doc1", "doc2", "doc3"], [1, 2], 'FINAL_TOP_N_FOR_CONTEXT')
-])
-def test_rerank_documents_predict_scenarios(mock_cross_encoder, mock_doc_factory, scores, initial_contents, expected_order_indices, top_n_config_key, mock_logger_fixture):
+
+@pytest.mark.parametrize(
+    "scores, initial_contents, expected_order_indices, top_n_config_key",
+    [
+        (
+            [0.1, 0.9, 0.5],
+            ["doc1", "doc2", "doc3"],
+            [1, 2, 0],
+            "FINAL_TOP_N_FOR_CONTEXT",
+        ),
+        (
+            [0.9, 0.5, 0.1],
+            ["doc1", "doc2", "doc3"],
+            [0, 1, 2],
+            "FINAL_TOP_N_FOR_CONTEXT",
+        ),
+        ([0.1, 0.9, 0.5], ["doc1", "doc2", "doc3"], [1, 2], "FINAL_TOP_N_FOR_CONTEXT"),
+    ],
+)
+def test_rerank_documents_predict_scenarios(
+    mock_cross_encoder,
+    mock_doc_factory,
+    scores,
+    initial_contents,
+    expected_order_indices,
+    top_n_config_key,
+    mock_logger_fixture,
+):
     mock_cross_encoder.predict.return_value = scores
     docs_to_rerank = [mock_doc_factory(content) for content in initial_contents]
 
     # Use a test-specific top_n, or ensure config.FINAL_TOP_N_FOR_CONTEXT is patched if used directly
     # The function signature uses top_n, so we pass it directly.
     # The original test_rag_deep used FINAL_TOP_N_FOR_CONTEXT, so we simulate that.
-    top_n_value = 2 if len(expected_order_indices) == 2 else 3 # Adjust based on expected output length
+    top_n_value = (
+        2 if len(expected_order_indices) == 2 else 3
+    )  # Adjust based on expected output length
 
-    reranked = rerank_documents("test query", docs_to_rerank, mock_cross_encoder, top_n=top_n_value)
+    reranked = rerank_documents(
+        "test query", docs_to_rerank, mock_cross_encoder, top_n=top_n_value
+    )
 
     assert len(reranked) == min(top_n_value, len(initial_contents))
-    expected_reranked_contents = [initial_contents[i] for i in expected_order_indices[:top_n_value]]
+    expected_reranked_contents = [
+        initial_contents[i] for i in expected_order_indices[:top_n_value]
+    ]
     assert [doc.page_content for doc in reranked] == expected_reranked_contents
     mock_cross_encoder.predict.assert_called_once()
-    mock_logger_fixture.info.assert_any_call("Document re-ranking prediction successful.")
+    mock_logger_fixture.info.assert_any_call(
+        "Document re-ranking prediction successful."
+    )
 
 
 def test_rerank_documents_model_none(mock_doc_factory, mock_logger_fixture):
@@ -249,15 +366,21 @@ def test_rerank_documents_model_none(mock_doc_factory, mock_logger_fixture):
     assert len(reranked) == 3
     assert [doc.page_content for doc in reranked] == ["doc0", "doc1", "doc2"]
     mock_st_warning.assert_called_once()
-    mock_logger_fixture.warning.assert_called_with("Re-ranker model not available. Skipping re-ranking.")
+    mock_logger_fixture.warning.assert_called_with(
+        "Re-ranker model not available. Skipping re-ranking."
+    )
 
 
-def test_rerank_documents_prediction_error(mock_cross_encoder, mock_doc_factory, mock_logger_fixture):
+def test_rerank_documents_prediction_error(
+    mock_cross_encoder, mock_doc_factory, mock_logger_fixture
+):
     mock_cross_encoder.predict.side_effect = Exception("Prediction failed")
     docs_to_rerank = [mock_doc_factory(f"doc{i}") for i in range(5)]
 
     with patch(STREAMLIT_ERROR_PATH) as mock_st_error:
-        reranked = rerank_documents("test query", docs_to_rerank, mock_cross_encoder, top_n=3)
+        reranked = rerank_documents(
+            "test query", docs_to_rerank, mock_cross_encoder, top_n=3
+        )
 
     assert len(reranked) == 3
     assert [doc.page_content for doc in reranked] == ["doc0", "doc1", "doc2"]
@@ -268,4 +391,6 @@ def test_rerank_documents_prediction_error(mock_cross_encoder, mock_doc_factory,
 def test_rerank_documents_empty_input(mock_cross_encoder, mock_logger_fixture):
     reranked = rerank_documents("test query", [], mock_cross_encoder, top_n=3)
     assert reranked == []
-    mock_logger_fixture.debug.assert_called_with("rerank_documents called with no documents.")
+    mock_logger_fixture.debug.assert_called_with(
+        "rerank_documents called with no documents."
+    )

--- a/tests/test_rag_deep.py
+++ b/tests/test_rag_deep.py
@@ -4,23 +4,24 @@ from unittest.mock import patch, MagicMock, ANY
 
 # Ensure rag_deep.py can be imported.
 import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Import items from rag_deep that are part of its direct UI logic or orchestration
 # For example, if there are any helper functions still in rag_deep.py or for patching its globals.
 # Most functions have moved to core, so imports from rag_deep itself will be minimal for testing.
 
 # Import core modules that will be mocked when testing rag_deep.py's orchestration
-from core import config as core_config # To access constants for assertions if needed
-from core import model_loader # To patch model loading if rag_deep re-imports them
+from core import config as core_config  # To access constants for assertions if needed
+from core import model_loader  # To patch model loading if rag_deep re-imports them
 from core import document_processing
 from core import search_pipeline
 from core import generation
 from core import session_manager
 
 from langchain_core.documents import Document as LangchainDocument
-from rank_bm25 import BM25Okapi 
-from sentence_transformers import CrossEncoder # For type checking mocks
+from rank_bm25 import BM25Okapi
+from sentence_transformers import CrossEncoder  # For type checking mocks
 
 # Define the path to test data files (might not be needed if core tests handle their own data)
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "test_data")
@@ -38,6 +39,7 @@ def setup_test_environment(tmp_path_factory):
         os.makedirs(TEST_DATA_DIR)
     # No actual file creation here unless specific integration tests in this file need them.
 
+
 @pytest.fixture
 def mock_streamlit_ui(mocker):
     """Mocks Streamlit UI elements and session state for rag_deep.py tests."""
@@ -53,50 +55,67 @@ def mock_streamlit_ui(mocker):
         "document_summary": None,
         "document_keywords": None,
         "bm25_index": None,
-        "bm25_corpus_chunks": []
+        "bm25_corpus_chunks": [],
     }
-    mocker.patch('rag_deep.st.session_state', new_callable=lambda: mock_session_dict)
+    mocker.patch("rag_deep.st.session_state", new_callable=lambda: mock_session_dict)
 
     # Mock other Streamlit calls if rag_deep.py uses them directly
-    mocker.patch('rag_deep.st.button', return_value=False) # Default to button not pressed
-    mocker.patch('rag_deep.st.file_uploader', return_value=None) # Default to no file uploaded
-    mocker.patch('rag_deep.st.chat_input', return_value=None) # Default to no user input
+    mocker.patch(
+        "rag_deep.st.button", return_value=False
+    )  # Default to button not pressed
+    mocker.patch(
+        "rag_deep.st.file_uploader", return_value=None
+    )  # Default to no file uploaded
+    mocker.patch(
+        "rag_deep.st.chat_input", return_value=None
+    )  # Default to no user input
     m_spinner = MagicMock()
     m_spinner.__enter__ = MagicMock(return_value=None)
     m_spinner.__exit__ = MagicMock(return_value=None)
-    mocker.patch('rag_deep.st.spinner', return_value=m_spinner)
-    mocker.patch('rag_deep.st.error')
-    mocker.patch('rag_deep.st.warning')
-    mocker.patch('rag_deep.st.info')
-    mocker.patch('rag_deep.st.success')
-    mocker.patch('rag_deep.st.markdown')
-    mocker.patch('rag_deep.st.sidebar', MagicMock()) # Mock sidebar object if calls like st.sidebar.button are made
-    mocker.patch('rag_deep.st.header')
-    mocker.patch('rag_deep.st.title')
-    mocker.patch('rag_deep.st.write')
-    mocker.patch('rag_deep.st.chat_message', MagicMock()) # Mock chat_message context manager
+    mocker.patch("rag_deep.st.spinner", return_value=m_spinner)
+    mocker.patch("rag_deep.st.error")
+    mocker.patch("rag_deep.st.warning")
+    mocker.patch("rag_deep.st.info")
+    mocker.patch("rag_deep.st.success")
+    mocker.patch("rag_deep.st.markdown")
+    mocker.patch(
+        "rag_deep.st.sidebar", MagicMock()
+    )  # Mock sidebar object if calls like st.sidebar.button are made
+    mocker.patch("rag_deep.st.header")
+    mocker.patch("rag_deep.st.title")
+    mocker.patch("rag_deep.st.write")
+    mocker.patch(
+        "rag_deep.st.chat_message", MagicMock()
+    )  # Mock chat_message context manager
 
     return mock_session_dict
 
 
 # --- Adapted Integration-Style Tests ---
 
+
 # Test for BM25 Indexing part of the main file processing logic in rag_deep.py
-@patch('rag_deep.index_documents') # Mocked as its tested in document_processing
-@patch('rag_deep.chunk_documents', return_value=[LangchainDocument(page_content="chunk")])
-@patch('rag_deep.load_document', return_value=[LangchainDocument(page_content="doc")])
-@patch('rag_deep.save_uploaded_file', return_value="dummy_path.pdf")
-@patch('rag_deep.reset_document_states')
+@patch("rag_deep.index_documents")  # Mocked as its tested in document_processing
+@patch(
+    "rag_deep.chunk_documents", return_value=[LangchainDocument(page_content="chunk")]
+)
+@patch("rag_deep.load_document", return_value=[LangchainDocument(page_content="doc")])
+@patch("rag_deep.save_uploaded_file", return_value="dummy_path.pdf")
+@patch("rag_deep.reset_document_states")
 def test_rag_deep_file_processing_flow_bm25_creation(
-    mock_reset_states, mock_save, mock_load, mock_chunk, mock_index_docs,
-    mock_streamlit_ui # Use the fixture to setup mocks for st calls and session_state
+    mock_reset_states,
+    mock_save,
+    mock_load,
+    mock_chunk,
+    mock_index_docs,
+    mock_streamlit_ui,  # Use the fixture to setup mocks for st calls and session_state
 ):
     # Simulate file upload
     mock_uploaded_file = MagicMock()
     mock_uploaded_file.name = "test.pdf"
-    mock_streamlit_ui['uploaded_file_key'] = 0
+    mock_streamlit_ui["uploaded_file_key"] = 0
     # Patch file_uploader to return our mock file
-    with patch('rag_deep.st.file_uploader', return_value=[mock_uploaded_file]):
+    with patch("rag_deep.st.file_uploader", return_value=[mock_uploaded_file]):
         # To simulate the script run after upload, we'd need to re-import or call a main function.
         # For a unit-like test of this block, we assume the block is triggered.
         # Here, we're testing the BM25 part which happens after index_documents sets document_processed = True
@@ -109,9 +128,11 @@ def test_rag_deep_file_processing_flow_bm25_creation(
         processed_chunks_for_bm25 = mock_chunk.return_value
 
         # --- This is the logic block from rag_deep.py we are testing ---
-        if mock_streamlit_ui["document_processed"]: # This will be true
+        if mock_streamlit_ui["document_processed"]:  # This will be true
             try:
-                corpus_texts = [chunk.page_content for chunk in processed_chunks_for_bm25]
+                corpus_texts = [
+                    chunk.page_content for chunk in processed_chunks_for_bm25
+                ]
                 tokenized_corpus = [doc.lower().split(" ") for doc in corpus_texts]
 
                 # The actual creation of BM25Okapi happens here
@@ -134,27 +155,36 @@ def test_rag_deep_file_processing_flow_bm25_creation(
 # --- Tests for Chat Logic Integration (adapted) ---
 # These tests verify that rag_deep.py correctly orchestrates calls to core modules.
 
-@patch('rag_deep.generate_answer')
-@patch('rag_deep.rerank_documents')
-@patch('rag_deep.combine_results_rrf')
-@patch('rag_deep.find_related_documents')
-@patch('rag_deep.RERANKER_MODEL', new_callable=MagicMock) # Patch the RERANKER_MODEL global in rag_deep.py
+
+@patch("rag_deep.generate_answer")
+@patch("rag_deep.rerank_documents")
+@patch("rag_deep.combine_results_rrf")
+@patch("rag_deep.find_related_documents")
+@patch(
+    "rag_deep.RERANKER_MODEL", new_callable=MagicMock
+)  # Patch the RERANKER_MODEL global in rag_deep.py
 def test_rag_deep_chat_logic_reranking_successful(
-    mock_rag_deep_reranker_model_instance, # This is the RERANKER_MODEL global
+    mock_rag_deep_reranker_model_instance,  # This is the RERANKER_MODEL global
     mock_core_find_related,
     mock_core_combine_rrf,
     mock_core_rerank_docs,
     mock_core_generate_answer,
-    mock_streamlit_ui # This provides mocked st.session_state
+    mock_streamlit_ui,  # This provides mocked st.session_state
 ):
     # Setup: Simulate that a document has been processed
     mock_streamlit_ui["document_processed"] = True
-    mock_streamlit_ui["messages"] = [] # Start with empty chat history
+    mock_streamlit_ui["messages"] = []  # Start with empty chat history
 
     # Configure mocks for core module functions
-    mock_core_find_related.return_value = {"semantic_results": [LangchainDocument("sem1")], "bm25_results": [LangchainDocument("bm25_1")]}
+    mock_core_find_related.return_value = {
+        "semantic_results": [LangchainDocument("sem1")],
+        "bm25_results": [LangchainDocument("bm25_1")],
+    }
 
-    hybrid_docs = [LangchainDocument(f"hybrid_doc_{i}") for i in range(core_config.TOP_K_FOR_RERANKER)]
+    hybrid_docs = [
+        LangchainDocument(f"hybrid_doc_{i}")
+        for i in range(core_config.TOP_K_FOR_RERANKER)
+    ]
     mock_core_combine_rrf.return_value = hybrid_docs
 
     # Ensure the global RERANKER_MODEL in rag_deep.py is the one we can check calls on
@@ -162,13 +192,16 @@ def test_rag_deep_chat_logic_reranking_successful(
     # If RERANKER_MODEL itself was None, the logic would differ. Here we test it exists.
     assert mock_rag_deep_reranker_model_instance is not None
 
-    reranked_final_docs = [LangchainDocument(f"reranked_doc_{i}") for i in range(core_config.FINAL_TOP_N_FOR_CONTEXT)]
+    reranked_final_docs = [
+        LangchainDocument(f"reranked_doc_{i}")
+        for i in range(core_config.FINAL_TOP_N_FOR_CONTEXT)
+    ]
     mock_core_rerank_docs.return_value = reranked_final_docs
 
     mock_core_generate_answer.return_value = "Final AI Answer from Orchestration"
 
     # Simulate user input via chat_input returning a value
-    with patch('rag_deep.st.chat_input', return_value="test user query"):
+    with patch("rag_deep.st.chat_input", return_value="test user query"):
         # To test the chat logic, we'd ideally call a main/run function of rag_deep.
         # Since rag_deep is a script, we simulate its flow if user_input is True.
         # This requires knowledge of rag_deep.py's structure.
@@ -176,8 +209,10 @@ def test_rag_deep_chat_logic_reranking_successful(
         # or we are testing the block `if user_input:`
 
         # Simplified simulation of rag_deep.py's internal chat handling block:
-        user_input_sim = "test user query" # from st.chat_input
-        mock_streamlit_ui["messages"].append({"role": "user", "content": user_input_sim})
+        user_input_sim = "test user query"  # from st.chat_input
+        mock_streamlit_ui["messages"].append(
+            {"role": "user", "content": user_input_sim}
+        )
 
         # --- Start of simulated block from rag_deep.py ---
         retrieved_results_dict = search_pipeline.find_related_documents(
@@ -185,71 +220,107 @@ def test_rag_deep_chat_logic_reranking_successful(
             mock_streamlit_ui["DOCUMENT_VECTOR_DB"],
             mock_streamlit_ui["bm25_index"],
             mock_streamlit_ui["bm25_corpus_chunks"],
-            mock_streamlit_ui["document_processed"]
+            mock_streamlit_ui["document_processed"],
         )
-        combined_hybrid_docs = search_pipeline.combine_results_rrf(retrieved_results_dict)
+        combined_hybrid_docs = search_pipeline.combine_results_rrf(
+            retrieved_results_dict
+        )
 
         final_context_docs_for_llm = []
         if combined_hybrid_docs:
-            docs_for_reranking = combined_hybrid_docs[:core_config.TOP_K_FOR_RERANKER]
-            if model_loader.RERANKER_MODEL: # Check the actual RERANKER_MODEL from model_loader used by rag_deep
-                 final_context_docs_for_llm = search_pipeline.rerank_documents(user_input_sim, docs_for_reranking, model_loader.RERANKER_MODEL, top_n=core_config.FINAL_TOP_N_FOR_CONTEXT)
+            docs_for_reranking = combined_hybrid_docs[: core_config.TOP_K_FOR_RERANKER]
+            if (
+                model_loader.RERANKER_MODEL
+            ):  # Check the actual RERANKER_MODEL from model_loader used by rag_deep
+                final_context_docs_for_llm = search_pipeline.rerank_documents(
+                    user_input_sim,
+                    docs_for_reranking,
+                    model_loader.RERANKER_MODEL,
+                    top_n=core_config.FINAL_TOP_N_FOR_CONTEXT,
+                )
             else:
                 # This path is for when RERANKER_MODEL is None
-                final_context_docs_for_llm = docs_for_reranking[:core_config.FINAL_TOP_N_FOR_CONTEXT]
+                final_context_docs_for_llm = docs_for_reranking[
+                    : core_config.FINAL_TOP_N_FOR_CONTEXT
+                ]
 
         if not final_context_docs_for_llm:
-            ai_response = "No relevant sections found." # Simplified
+            ai_response = "No relevant sections found."  # Simplified
         else:
             ai_response = generation.generate_answer(
-                model_loader.LANGUAGE_MODEL, # Assuming LANGUAGE_MODEL is loaded
+                model_loader.LANGUAGE_MODEL,  # Assuming LANGUAGE_MODEL is loaded
                 user_query=user_input_sim,
                 context_documents=final_context_docs_for_llm,
-                conversation_history=""
+                conversation_history="",
             )
-        mock_streamlit_ui["messages"].append({"role": "assistant", "content": ai_response})
+        mock_streamlit_ui["messages"].append(
+            {"role": "assistant", "content": ai_response}
+        )
         # --- End of simulated block ---
 
     # Assertions
     mock_core_find_related.assert_called_once_with(user_input_sim, ANY, ANY, ANY, True)
     mock_core_combine_rrf.assert_called_once_with(mock_core_find_related.return_value)
-    
+
     # Check if RERANKER_MODEL (the global one in rag_deep, which is mock_rag_deep_reranker_model_instance) was used
     # The actual rerank_documents function is mocked as mock_core_rerank_docs.
     # We need to assert that the core.search_pipeline.rerank_documents was called correctly.
-    mock_core_rerank_docs.assert_called_once_with(user_input_sim, hybrid_docs[:core_config.TOP_K_FOR_RERANKER], model_loader.RERANKER_MODEL, top_n=core_config.FINAL_TOP_N_FOR_CONTEXT)
-    
-    mock_core_generate_answer.assert_called_once_with(model_loader.LANGUAGE_MODEL, user_query=user_input_sim, context_documents=reranked_final_docs, conversation_history="")
-    assert mock_streamlit_ui["messages"][-1]["content"] == "Final AI Answer from Orchestration"
+    mock_core_rerank_docs.assert_called_once_with(
+        user_input_sim,
+        hybrid_docs[: core_config.TOP_K_FOR_RERANKER],
+        model_loader.RERANKER_MODEL,
+        top_n=core_config.FINAL_TOP_N_FOR_CONTEXT,
+    )
+
+    mock_core_generate_answer.assert_called_once_with(
+        model_loader.LANGUAGE_MODEL,
+        user_query=user_input_sim,
+        context_documents=reranked_final_docs,
+        conversation_history="",
+    )
+    assert (
+        mock_streamlit_ui["messages"][-1]["content"]
+        == "Final AI Answer from Orchestration"
+    )
 
 
-@patch('rag_deep.generate_answer')
-@patch('rag_deep.rerank_documents')
-@patch('rag_deep.combine_results_rrf')
-@patch('rag_deep.find_related_documents')
-@patch('rag_deep.RERANKER_MODEL', None) # Critical: Patch the global RERANKER_MODEL in rag_deep to be None
-@patch('rag_deep.st.info') # To check the st.info call
+@patch("rag_deep.generate_answer")
+@patch("rag_deep.rerank_documents")
+@patch("rag_deep.combine_results_rrf")
+@patch("rag_deep.find_related_documents")
+@patch(
+    "rag_deep.RERANKER_MODEL", None
+)  # Critical: Patch the global RERANKER_MODEL in rag_deep to be None
+@patch("rag_deep.st.info")  # To check the st.info call
 def test_rag_deep_chat_logic_reranker_model_none(
     mock_st_info,
-    mock_rag_deep_reranker_model_is_none, # This is the RERANKER_MODEL = None patch
+    mock_rag_deep_reranker_model_is_none,  # This is the RERANKER_MODEL = None patch
     mock_core_find_related,
     mock_core_combine_rrf,
     mock_core_rerank_docs,
     mock_core_generate_answer,
-    mock_streamlit_ui
+    mock_streamlit_ui,
 ):
     mock_streamlit_ui["document_processed"] = True
     mock_streamlit_ui["messages"] = []
 
-    mock_core_find_related.return_value = {"semantic_results": [LangchainDocument("sem1")], "bm25_results": [LangchainDocument("bm25_1")]}
-    hybrid_docs = [LangchainDocument(f"hybrid_doc_{i}") for i in range(core_config.TOP_K_FOR_RERANKER)]
+    mock_core_find_related.return_value = {
+        "semantic_results": [LangchainDocument("sem1")],
+        "bm25_results": [LangchainDocument("bm25_1")],
+    }
+    hybrid_docs = [
+        LangchainDocument(f"hybrid_doc_{i}")
+        for i in range(core_config.TOP_K_FOR_RERANKER)
+    ]
     mock_core_combine_rrf.return_value = hybrid_docs
     mock_core_generate_answer.return_value = "Fallback AI Answer"
 
     # Simulate user input
-    with patch('rag_deep.st.chat_input', return_value="test user query"):
+    with patch("rag_deep.st.chat_input", return_value="test user query"):
         user_input_sim = "test user query"
-        mock_streamlit_ui["messages"].append({"role": "user", "content": user_input_sim})
+        mock_streamlit_ui["messages"].append(
+            {"role": "user", "content": user_input_sim}
+        )
 
         # --- Start of simulated block from rag_deep.py ---
         # This time, RERANKER_MODEL (from rag_deep's global scope) is None
@@ -258,23 +329,39 @@ def test_rag_deep_chat_logic_reranker_model_none(
         # For this test, we focus on rag_deep.RERANKER_MODEL being None.
 
         # Patch model_loader.RERANKER_MODEL to ensure the `if model_loader.RERANKER_MODEL:` check in rag_deep.py uses this
-        with patch('rag_deep.model_loader.RERANKER_MODEL', None):
+        with patch("rag_deep.model_loader.RERANKER_MODEL", None):
             retrieved_results_dict = search_pipeline.find_related_documents(
-                user_input_sim, mock_streamlit_ui["DOCUMENT_VECTOR_DB"], mock_streamlit_ui["bm25_index"],
-                mock_streamlit_ui["bm25_corpus_chunks"], mock_streamlit_ui["document_processed"]
+                user_input_sim,
+                mock_streamlit_ui["DOCUMENT_VECTOR_DB"],
+                mock_streamlit_ui["bm25_index"],
+                mock_streamlit_ui["bm25_corpus_chunks"],
+                mock_streamlit_ui["document_processed"],
             )
-            combined_hybrid_docs = search_pipeline.combine_results_rrf(retrieved_results_dict)
+            combined_hybrid_docs = search_pipeline.combine_results_rrf(
+                retrieved_results_dict
+            )
 
             final_context_docs_for_llm = []
             if combined_hybrid_docs:
-                docs_for_reranking = combined_hybrid_docs[:core_config.TOP_K_FOR_RERANKER]
+                docs_for_reranking = combined_hybrid_docs[
+                    : core_config.TOP_K_FOR_RERANKER
+                ]
                 # This 'if' condition in rag_deep.py will use the patched rag_deep.model_loader.RERANKER_MODEL
                 if model_loader.RERANKER_MODEL:
-                     final_context_docs_for_llm = search_pipeline.rerank_documents(user_input_sim, docs_for_reranking, model_loader.RERANKER_MODEL, top_n=core_config.FINAL_TOP_N_FOR_CONTEXT)
+                    final_context_docs_for_llm = search_pipeline.rerank_documents(
+                        user_input_sim,
+                        docs_for_reranking,
+                        model_loader.RERANKER_MODEL,
+                        top_n=core_config.FINAL_TOP_N_FOR_CONTEXT,
+                    )
                 else:
                     # This path should be taken
-                    mock_st_info("Re-ranker model not loaded. Using documents from hybrid search directly (top results).")
-                    final_context_docs_for_llm = docs_for_reranking[:core_config.FINAL_TOP_N_FOR_CONTEXT]
+                    mock_st_info(
+                        "Re-ranker model not loaded. Using documents from hybrid search directly (top results)."
+                    )
+                    final_context_docs_for_llm = docs_for_reranking[
+                        : core_config.FINAL_TOP_N_FOR_CONTEXT
+                    ]
 
             if not final_context_docs_for_llm:
                 ai_response = "No relevant sections found."
@@ -283,20 +370,30 @@ def test_rag_deep_chat_logic_reranker_model_none(
                     model_loader.LANGUAGE_MODEL,
                     user_query=user_input_sim,
                     context_documents=final_context_docs_for_llm,
-                    conversation_history=""
+                    conversation_history="",
                 )
-            mock_streamlit_ui["messages"].append({"role": "assistant", "content": ai_response})
+            mock_streamlit_ui["messages"].append(
+                {"role": "assistant", "content": ai_response}
+            )
         # --- End of simulated block ---
 
     mock_core_find_related.assert_called_once()
     mock_core_combine_rrf.assert_called_once()
-    mock_core_rerank_docs.assert_not_called() # Crucially, rerank_documents from core.search_pipeline should not be called
+    mock_core_rerank_docs.assert_not_called()  # Crucially, rerank_documents from core.search_pipeline should not be called
 
-    mock_st_info.assert_called_once_with("Re-ranker model not loaded. Using documents from hybrid search directly (top results).")
+    mock_st_info.assert_called_once_with(
+        "Re-ranker model not loaded. Using documents from hybrid search directly (top results)."
+    )
 
-    expected_context_docs = hybrid_docs[:core_config.FINAL_TOP_N_FOR_CONTEXT]
-    mock_core_generate_answer.assert_called_once_with(model_loader.LANGUAGE_MODEL, user_query=user_input_sim, context_documents=expected_context_docs, conversation_history="")
+    expected_context_docs = hybrid_docs[: core_config.FINAL_TOP_N_FOR_CONTEXT]
+    mock_core_generate_answer.assert_called_once_with(
+        model_loader.LANGUAGE_MODEL,
+        user_query=user_input_sim,
+        context_documents=expected_context_docs,
+        conversation_history="",
+    )
     assert mock_streamlit_ui["messages"][-1]["content"] == "Fallback AI Answer"
+
 
 # Placeholder for any other UI-specific tests that might remain for rag_deep.py
 # For example, testing the state changes from sidebar button clicks if they don't directly map


### PR DESCRIPTION
I reformatted Python files across your project (core modules, tests, main script) to adhere to Black code style standards. This addresses issues caught by the 'black --check' step in the CI pipeline.