### PR TITLE
fix(tests): Add missing import for streamlit in test_rag_deep.py

### DIFF
--- a/tests/test_rag_deep.py
+++ b/tests/test_rag_deep.py
@@ -1,6 +1,7 @@
 import pytest
 import os
 from unittest.mock import patch, MagicMock, ANY
+import streamlit as st # Add this import to define 'st' in the test file's scope
 
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))


### PR DESCRIPTION
Added `import streamlit as st` to `tests/test_rag_deep.py` to resolve an `F821 undefined name 'st'` error. This error occurred when a replicated block of code from `rag_deep.py` (used for integration testing purposes within the test file) attempted to call `st.info()`.

The relevant test methods are already patching `rag_deep.st.info` (or similar) to assert calls made by the `rag_deep` module itself. This change ensures that the replicated code block within the test can execute without a NameError if it also contains `st.*` calls.